### PR TITLE
Fix stun status update in InputController

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -21,9 +21,9 @@ local Stun = Remotes:WaitForChild("Stun") -- Confirmed no "Remotes" suffix in fo
 
 local StunStatusEvent = Stun:WaitForChild("StunStatusRequestEvent")
 
+-- Update stun status using the provided helper instead of overwriting the API
 StunStatusEvent.OnClientEvent:Connect(function(data)
-	StunStatusClient.IsStunned = data.Stunned
-	StunStatusClient.IsAttackerLocked = data.AttackerLock
+        StunStatusClient.SetStatus(data.Stunned, data.AttackerLock)
 end)
 
 -- 🔗 Tool event connection


### PR DESCRIPTION
## Summary
- fix InputController so it uses `StunStatusClient.SetStatus` instead of overwriting exported functions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68406619264c832db6f88311c704ce5e