### PR TITLE
Fix stun handler to use API function

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -22,8 +22,7 @@ local Stun = Remotes:WaitForChild("Stun") -- Confirmed no "Remotes" suffix in fo
 local StunStatusEvent = Stun:WaitForChild("StunStatusRequestEvent")
 
 StunStatusEvent.OnClientEvent:Connect(function(data)
-	StunStatusClient.IsStunned = data.Stunned
-	StunStatusClient.IsAttackerLocked = data.AttackerLock
+        StunStatusClient.SetStatus(data.Stunned, data.AttackerLock)
 end)
 
 -- 🔗 Tool event connection


### PR DESCRIPTION
## Summary
- use StunStatusClient.SetStatus in InputController

## Testing
- `rojo build default.project.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684067c3428c832d9eafab48f6b8da6e