### PR TITLE
Fix comment typo in Animate client

### DIFF
--- a/src/Workspace/Rig/Animate.client.lua
+++ b/src/Workspace/Rig/Animate.client.lua
@@ -103,7 +103,7 @@ local animNames = {
 			},
 }
 
--- Existance in this list signifies that it is an emote, the value indicates if it is a looping emote
+-- Existence in this list signifies that it is an emote, the value indicates if it is a looping emote
 local emoteNames = { wave = false, point = false, dance = true, dance2 = true, dance3 = true, laugh = false, cheer = false}
 
 math.randomseed(tick())


### PR DESCRIPTION
## Summary
- fix a typo in `Animate.client.lua` documentation comment

## Testing
- `grep -n Existence -n src/Workspace/Rig/Animate.client.lua`

------
https://chatgpt.com/codex/tasks/task_e_684067c6a514832d987bc75d67e82083