### PR TITLE
Fix block and stun animations

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -10,6 +10,7 @@ local player = Players.LocalPlayer
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
+local CombatAnimations = require(ReplicatedStorage.Modules.Animations.Combat)
 
 -- ✅ Fixed remote path
 local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
@@ -19,13 +20,47 @@ local BlockEvent = CombatRemotes:WaitForChild("BlockEvent")
 local isBlocking = false
 local lastBlockEnd = 0
 local blockCooldown = CombatConfig.Blocking.BlockCooldown or 2
+local blockTrack: AnimationTrack? = nil
+
+local function playBlockAnimation()
+        local char = player.Character
+        local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+        local animId = CombatAnimations.Blocking.BlockHold
+        if not humanoid or not animId then return end
+        local animator = humanoid:FindFirstChildOfClass("Animator")
+        if not animator then return end
+
+        local anim = Instance.new("Animation")
+        anim.AnimationId = animId
+        local track = animator:LoadAnimation(anim)
+        track.Priority = Enum.AnimationPriority.Action
+        track.Looped = true
+        track:Play()
+        blockTrack = track
+        ToolController.PauseStance()
+end
+
+local function stopBlockAnimation()
+        if blockTrack then
+                blockTrack:Stop()
+                blockTrack:Destroy()
+                blockTrack = nil
+        end
+        ToolController.ResumeStance()
+end
 
 -- Sync from server when block state is forcibly ended (broken or cancelled)
 BlockEvent.OnClientEvent:Connect(function(active)
-        isBlocking = active
-        if not active then
-                lastBlockEnd = tick()
+    isBlocking = active
+    if active then
+        -- Avoid starting the animation twice if we already began locally
+        if not blockTrack then
+            playBlockAnimation()
         end
+    else
+        lastBlockEnd = tick()
+        stopBlockAnimation()
+    end
 end)
 
 -- Checks if the current tool allows blocking
@@ -63,8 +98,9 @@ function BlockClient.OnInputBegan(input, gameProcessed)
 		return
 	end
 
-	isBlocking = true
-	BlockEvent:FireServer(true)
+        isBlocking = true
+        playBlockAnimation()
+        BlockEvent:FireServer(true)
 end
 
 -- Input ended: stop blocking
@@ -74,9 +110,10 @@ function BlockClient.OnInputEnded(input, gameProcessed)
 
 	if not isBlocking then return end
 
-	isBlocking = false
-	lastBlockEnd = tick()
-	BlockEvent:FireServer(false)
+        isBlocking = false
+        lastBlockEnd = tick()
+        stopBlockAnimation()
+        BlockEvent:FireServer(false)
 end
 
 function BlockClient.IsBlocking()

--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -42,7 +42,13 @@ function StunService:CanBeHitBy(attacker, target)
         return true
 end
 
-function StunService:ApplyStun(targetHumanoid, duration, skipAnim, attacker)
+--[[@
+        ApplyStun applies a stun to the target humanoid for the given duration.
+        The third parameter can either be:
+                * boolean true/false to indicate if the default animation should be skipped
+                * a string/number representing a custom animation id to play
+]]
+function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker)
 	local targetPlayer = getPlayer(targetHumanoid)
 	local attackerPlayer = getPlayer(attacker)
 	if not targetPlayer or not attackerPlayer then return end
@@ -56,28 +62,36 @@ function StunService:ApplyStun(targetHumanoid, duration, skipAnim, attacker)
 		StunnedPlayers[targetPlayer] = nil
 	end
 
-	if ActiveAnimations[targetPlayer] then
-		ActiveAnimations[targetPlayer]:Stop()
-		ActiveAnimations[targetPlayer]:Destroy()
-		ActiveAnimations[targetPlayer] = nil
-	end
+       if ActiveAnimations[targetPlayer] then
+                ActiveAnimations[targetPlayer]:Stop()
+                ActiveAnimations[targetPlayer]:Destroy()
+                ActiveAnimations[targetPlayer] = nil
+       end
 
-	targetHumanoid.WalkSpeed = 0
-	targetHumanoid.JumpPower = 0
+       targetHumanoid.WalkSpeed = 0
+       targetHumanoid.JumpPower = 0
 
-	if not skipAnim then
-		local animator = targetHumanoid:FindFirstChildOfClass("Animator")
-		local stunAnimId = CombatAnimations.Stun.Default
-		if animator and stunAnimId then
-			local anim = Instance.new("Animation")
-			anim.AnimationId = stunAnimId
-			local track = animator:LoadAnimation(anim)
-			track.Priority = Enum.AnimationPriority.Action
-			track.Looped = false
-			track:Play()
-			ActiveAnimations[targetPlayer] = track
-		end
-	end
+       local skipAnim = false
+       local stunAnimId = CombatAnimations.Stun.Default
+
+       if typeof(animOrSkip) == "boolean" then
+                skipAnim = animOrSkip
+       elseif animOrSkip ~= nil then
+                stunAnimId = animOrSkip
+       end
+
+       if not skipAnim then
+                local animator = targetHumanoid:FindFirstChildOfClass("Animator")
+                if animator and stunAnimId then
+                        local anim = Instance.new("Animation")
+                        anim.AnimationId = tostring(stunAnimId)
+                        local track = animator:LoadAnimation(anim)
+                        track.Priority = Enum.AnimationPriority.Action
+                        track.Looped = false
+                        track:Play()
+                        ActiveAnimations[targetPlayer] = track
+                end
+       end
 
 	local conn
 	conn = RunService.Heartbeat:Connect(function()

--- a/src/ReplicatedStorage/Modules/Combat/ToolController.lua
+++ b/src/ReplicatedStorage/Modules/Combat/ToolController.lua
@@ -22,7 +22,21 @@ function ToolController.GetEquippedTool()
 end
 
 function ToolController.GetEquippedStyleKey()
-	return equippedStyleKey
+        return equippedStyleKey
+end
+
+-- 💤 Temporarily stop the idle stance animation
+function ToolController.PauseStance()
+        if activeStance and activeStance.IsPlaying then
+                activeStance:Stop()
+        end
+end
+
+-- ▶️ Resume the idle stance animation if it exists
+function ToolController.ResumeStance()
+        if activeStance and not activeStance.IsPlaying then
+                activeStance:Play()
+        end
 end
 
 -- 🛠️ Equipping logic

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -112,14 +112,13 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
 
                local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, damage, false)
                 if blockResult == "Perfect" then
-                        StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
-                        PlayAnimation(humanoid, AnimationData.Stun.PerfectBlock, "Knockback")
+                        StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
                         BlockEvent:FireClient(enemyPlayer, false)
                         continue
                 elseif blockResult == "Damaged" then
                         continue
                 elseif blockResult == "Broken" then
-                        StunService:ApplyStun(enemyHumanoid, BlockService.GetBlockBreakStunDuration(), false, player)
+                        StunService:ApplyStun(enemyHumanoid, BlockService.GetBlockBreakStunDuration(), AnimationData.Stun.BlockBreak, player)
                         BlockEvent:FireClient(enemyPlayer, false)
                         continue
                 end


### PR DESCRIPTION
## Summary
- play BlockHold animation when holding block
- pause tool stance while blocking and resume when released
- clear stun animation after duration using StunService
- have CombatService pass custom anim IDs for block outcomes
- prevent duplicate block animations

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68407e2b99c0832da3fad96cb6f116ea