### PR TITLE
Fix missing remote events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # GrandlineBattlegrounds
 
+This project contains the core scripts and modules for the game. To ensure all required `RemoteEvent` objects exist when running in a fresh place, the server script at `ServerScriptService/Misc/RemoteSetup.server.lua` will create any missing remotes inside `ReplicatedStorage/Remotes`.
+
+Several core server scripts emit initialization messages to the output so you can confirm they are running.

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -9,6 +9,8 @@ local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
 local AnimationData = require(ReplicatedStorage.Modules.Animations.Combat)
 
+print("[CombatService] Loaded")
+
 local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)

--- a/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
+++ b/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
@@ -35,7 +35,9 @@ end)
 
 -- ✅ For any characters already present (e.g., in Studio or on hot reload)
 for _, player in ipairs(Players:GetPlayers()) do
-	if player.Character then
-		setCollisionGroupRecursive(player.Character)
-	end
+        if player.Character then
+                setCollisionGroupRecursive(player.Character)
+        end
 end
+
+print("[PlayerCollisionDisabler] Initialized")

--- a/src/ServerScriptService/Misc/RemoteSetup.server.lua
+++ b/src/ServerScriptService/Misc/RemoteSetup.server.lua
@@ -1,0 +1,59 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+print("[RemoteSetup] Ensuring remotes exist")
+
+local function ensureFolder(parent, name)
+    local folder = parent:FindFirstChild(name)
+    if not folder then
+        folder = Instance.new("Folder")
+        folder.Name = name
+        folder.Parent = parent
+    end
+    return folder
+end
+
+local function ensureEvent(parent, name)
+    local evt = parent:FindFirstChild(name)
+    if not evt then
+        evt = Instance.new("RemoteEvent")
+        evt.Name = name
+        evt.Parent = parent
+    end
+    return evt
+end
+
+-- Root Remotes folder
+local remotes = ReplicatedStorage:FindFirstChild("Remotes") or Instance.new("Folder")
+remotes.Name = "Remotes"
+remotes.Parent = ReplicatedStorage
+
+-- Combat events
+local combat = ensureFolder(remotes, "Combat")
+ensureEvent(combat, "M1Event")
+ensureEvent(combat, "HitConfirmEvent")
+ensureEvent(combat, "BlockEvent")
+ensureEvent(combat, "JumpCooldownEvent")
+ensureEvent(combat, "PartyTableKickStart")
+ensureEvent(combat, "PartyTableKickHit")
+
+-- Movement events
+local movement = ensureFolder(remotes, "Movement")
+ensureEvent(movement, "DashEvent")
+ensureEvent(movement, "SprintStateEvent")
+
+-- Stun events
+local stun = ensureFolder(remotes, "Stun")
+ensureEvent(stun, "StunStatusRequestEvent")
+
+-- UI events
+local ui = ensureFolder(remotes, "UI")
+ensureEvent(ui, "PlayerEnteredMenu")
+ensureEvent(ui, "PlayerLeftMenu")
+ensureEvent(ui, "ReturnToMenuEvent")
+
+-- System events
+local system = ensureFolder(remotes, "System")
+ensureEvent(system, "SpawnRequestEvent")
+
+print("[RemoteSetup] Remotes verified")
+

--- a/src/ServerScriptService/Misc/ServerMenuVisibility.server.lua
+++ b/src/ServerScriptService/Misc/ServerMenuVisibility.server.lua
@@ -68,8 +68,10 @@ PlayerLeftMenu.OnServerEvent:Connect(function(player)
 end)
 
 Players.PlayerRemoving:Connect(function(player)
-	if menuConns[player] then
-		menuConns[player]:Disconnect()
-		menuConns[player] = nil
-	end
+        if menuConns[player] then
+                menuConns[player]:Disconnect()
+                menuConns[player] = nil
+        end
 end)
+
+print("[ServerMenuVisibility] Initialized")

--- a/src/ServerScriptService/Movement/DashServer.server.lua
+++ b/src/ServerScriptService/Movement/DashServer.server.lua
@@ -37,3 +37,5 @@ DashEvent.OnServerEvent:Connect(function(player, direction, dashVector)
         -- Always forward dashVector to the DashModule (module handles all logic now)
         DashModule.ExecuteDash(player, direction, dashVector)
 end)
+
+print("[DashServer] Ready")

--- a/src/ServerScriptService/Spawner/DeathHandler.server.lua
+++ b/src/ServerScriptService/Spawner/DeathHandler.server.lua
@@ -26,5 +26,7 @@ end)
 
 -- 🔁 Clean up on leave
 Players.PlayerRemoving:Connect(function(player)
-	hasSpawned[player] = nil
+        hasSpawned[player] = nil
 end)
+
+print("[DeathHandler] Initialized")

--- a/src/ServerScriptService/Spawner/RealSpawner.server.lua
+++ b/src/ServerScriptService/Spawner/RealSpawner.server.lua
@@ -75,3 +75,5 @@ local function spawnPlayerWithTool(player, toolName)
 end
 
 SpawnRequestEvent.OnServerEvent:Connect(spawnPlayerWithTool)
+
+print("[RealSpawner] Initialized")


### PR DESCRIPTION
## Summary
- add `RemoteSetup` server script to create missing RemoteEvents
- document remote creation logic in README
- emit debug prints when key server scripts initialize

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684091164a84832dac4dfd2000d4a5a6