### PR TITLE
Fix recursive module require in client scripts

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -12,7 +12,8 @@ local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
 local CombatAnimations = require(ReplicatedStorage.Modules.Animations.Combat)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
-local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
+-- Lazy reference to avoid circular require with MovementClient
+local MovementClient
 
 -- ✅ Fixed remote path
 local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
@@ -106,6 +107,9 @@ function BlockClient.OnInputBegan(input, gameProcessed)
 	end
 
         isBlocking = true
+        if not MovementClient then
+                MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
+        end
         MovementClient.StopSprint()
         playBlockAnimation()
         BlockEvent:FireServer(true)


### PR DESCRIPTION
## Summary
- avoid circular require between `BlockClient` and `MovementClient` by lazily loading `MovementClient`

## Testing
- `grep -n StopSprint -R`

------
https://chatgpt.com/codex/tasks/task_e_684095cf94bc832daf22a5badd909960