### PR TITLE
Fix combat hitbox timing

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
@@ -56,22 +56,23 @@ function M1InputClient.OnInputBegan(input, gameProcessed)
                 M1Event:FireServer(comboIndex, styleKey)
                 print("[M1InputClient] ComboIndex:", comboIndex)
 
-                -- Temporarily lock other actions during the attack
-                local lockDur = CombatConfig.M1.DelayBetweenHits + CombatConfig.M1.HitDelay
+                -- Temporarily lock other actions only for the base delay
+                -- so follow-up attacks can start exactly at DelayBetweenHits
+                local lockDur = CombatConfig.M1.DelayBetweenHits
                 StunStatusClient.LockFor(lockDur)
 
 		-- 🎬 Local animation
 		M1AnimationClient.Play(styleKey, comboIndex)
 
 		-- 🧊 Trigger hitbox
-		task.delay(CombatConfig.M1.HitDelay, function()
-			if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
-			HitboxClient.CastHitbox(
-				CombatConfig.M1.HitboxOffset,
-				CombatConfig.M1.HitboxSize,
-				CombatConfig.M1.HitboxDuration
-			)
-		end)
+                task.delay(CombatConfig.M1.HitDelay, function()
+                        if StunStatusClient.IsStunned() then return end
+                        HitboxClient.CastHitbox(
+                                CombatConfig.M1.HitboxOffset,
+                                CombatConfig.M1.HitboxSize,
+                                CombatConfig.M1.HitboxDuration
+                        )
+                end)
 
 		-- ⏱️ Combo advance / cooldown
 		task.delay(CombatConfig.M1.DelayBetweenHits, function()

--- a/src/ReplicatedStorage/Modules/Config/Config.lua
+++ b/src/ReplicatedStorage/Modules/Config/Config.lua
@@ -7,8 +7,9 @@ Config.GameSettings = {
 	DefaultWalkSpeed = 10,
 	DefaultJumpPower = 50,
 
-	JumpCooldown = 1.25,
-	DebugEnabled = true, -- Global debug toggle
+        JumpCooldown = 1.25,
+        DebugEnabled = true, -- Global debug toggle
+        AttackerLockoutDuration = 0, -- Remove extra delay after hits
 }
 
 return Config


### PR DESCRIPTION
## Summary
- let M1 hitboxes spawn during local lock by not checking attacker lock
- disable extra lockout after hitting by setting `AttackerLockoutDuration` to 0
- reduce local lock to DelayBetweenHits only

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840a5d38054832db253be127da060d3