### PR TITLE
Replicate dash VFX and SFX to all players

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -157,8 +157,23 @@ function DashClient.OnInputBegan(input, gameProcessed)
 	end
 
 	-- Notify server for validation (state only)
-	DashEvent:FireServer(direction, dashVector)
+        DashEvent:FireServer(direction, dashVector)
 end
+
+-- Play dash VFX/SFX when another player dashes
+DashEvent.OnClientEvent:Connect(function(dashPlayer, direction)
+        if dashPlayer == player then return end
+        if typeof(direction) ~= "string" then return end
+
+        local char = dashPlayer.Character
+        local hrp = char and char:FindFirstChild("HumanoidRootPart")
+        if not hrp then return end
+
+        if DashConfig.SoundId and DashConfig.SoundId ~= "" then
+                SoundServiceUtils:PlaySpatialSound(DashConfig.SoundId, hrp)
+        end
+        DashVFX:PlayDashEffect(direction, hrp)
+end)
 
 function DashClient.OnInputEnded() end
 

--- a/src/ServerScriptService/Movement/DashServer.server.lua
+++ b/src/ServerScriptService/Movement/DashServer.server.lua
@@ -34,8 +34,11 @@ DashEvent.OnServerEvent:Connect(function(player, direction, dashVector)
                return
        end
 
-        -- Always forward dashVector to the DashModule (module handles all logic now)
-        DashModule.ExecuteDash(player, direction, dashVector)
+       -- Always forward dashVector to the DashModule (module handles all logic now)
+       DashModule.ExecuteDash(player, direction, dashVector)
+
+       -- Notify all clients so they can play VFX/SFX for this dash
+       DashEvent:FireAllClients(player, direction)
 end)
 
 print("[DashServer] Ready")


### PR DESCRIPTION
## Summary
- broadcast dash events to all clients
- handle remote dash events client-side to play VFX and sounds for other players

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ae8adbc8832d85e31e487ac108e8