### PR TITLE
Fix moves folder require

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -18,8 +18,9 @@ local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 
--- Moves folder has an `init` ModuleScript, requiring the folder loads it
-local Moves = require(ReplicatedStorage.Modules.Combat.Moves)
+-- Explicitly require the init ModuleScript to avoid folder require issues
+local MovesFolder = ReplicatedStorage:WaitForChild("Modules"):WaitForChild("Combat"):WaitForChild("Moves")
+local Moves = require(MovesFolder:WaitForChild("init"))
 if DEBUG then
     print("[InputController] Loaded moves:", #Moves)
 end


### PR DESCRIPTION
## Summary
- fix requiring the Moves folder by explicitly loading the `init` ModuleScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c4ebe668832db30cab7292bdeb7d