### PR TITLE
Fix Moves folder export

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/init.meta.json
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/init.meta.json
@@ -1,3 +1,4 @@
 {
+  "className": "Folder",
   "ignoreUnknownInstances": true
 }


### PR DESCRIPTION
## Summary
- ensure the `Moves` directory is exported as a Folder so it contains an `init` ModuleScript

## Testing
- `rojo build default.project.json -o build.rbxl` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c8d2beec832da87d04c868e136b8