### PR TITLE
Fix moves config references

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/MovesConfig.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/MovesConfig.lua
@@ -1,4 +1,5 @@
-local MovesConfig = {}
+local Moves = {}
+
 local folder = script.Parent
 for _, obj in ipairs(folder:GetChildren()) do
     if obj:IsA("ModuleScript") and obj ~= script then
@@ -8,4 +9,5 @@ for _, obj in ipairs(folder:GetChildren()) do
         end
     end
 end
-return MovesConfig
+
+return Moves

--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -18,9 +18,9 @@ local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 
--- Explicitly require the init ModuleScript to avoid folder require issues
+-- Load client combat moves from MovesConfig
 local MovesFolder = ReplicatedStorage:WaitForChild("Modules"):WaitForChild("Combat"):WaitForChild("Moves")
-local Moves = require(MovesFolder:WaitForChild("init"))
+local Moves = require(MovesFolder:WaitForChild("MovesConfig"))
 if DEBUG then
     print("[InputController] Loaded moves:", #Moves)
 end


### PR DESCRIPTION
## Summary
- load moves from `MovesConfig` instead of `init`
- return table of move modules from `MovesConfig`

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7e4ff38832dac66e0aaa9700688