### PR TITLE
Ensure MovesConfig loads modules deterministically

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/MovesConfig.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/MovesConfig.lua
@@ -1,12 +1,23 @@
 local Moves = {}
 
 local folder = script.Parent
+
+-- Collect module scripts first so we can load them in a deterministic order
+local moduleScripts = {}
 for _, obj in ipairs(folder:GetChildren()) do
     if obj:IsA("ModuleScript") and obj ~= script then
-        local ok, mod = pcall(require, obj)
-        if ok and type(mod) == "table" then
-            table.insert(Moves, mod)
-        end
+        table.insert(moduleScripts, obj)
+    end
+end
+
+table.sort(moduleScripts, function(a, b)
+    return a.Name < b.Name
+end)
+
+for _, moduleScript in ipairs(moduleScripts) do
+    local ok, mod = pcall(require, moduleScript)
+    if ok and type(mod) == "table" then
+        table.insert(Moves, mod)
     end
 end
 

--- a/src/ReplicatedStorage/Modules/Combat/Moves/init.meta.json
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/init.meta.json
@@ -1,4 +1,0 @@
-{
-  "className": "Folder",
-  "ignoreUnknownInstances": true
-}


### PR DESCRIPTION
## Summary
- sort move ModuleScripts before requiring them to ensure deterministic loading order
- remove obsolete `init.meta.json` file from moves folder

## Testing
- `./rojo/rojo --version`
- `./rojo/rojo build default.project.json -o game.rbxl`
- `echo 'No tests specified'`


------
https://chatgpt.com/codex/tasks/task_e_6841012f6f80832d8c617a2a465feb67