### PR TITLE
Add per-move config for Party Table Kick

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 This project contains the core scripts and modules for the game. To ensure all required `RemoteEvent` objects exist when running in a fresh place, the server script at `ServerScriptService/Misc/RemoteSetup.server.lua` will create any missing remotes inside `ReplicatedStorage/Remotes`.
 
 Several core server scripts emit initialization messages to the output so you can confirm they are running.
+
+## Hitbox Configuration
+
+Hitbox sizes, offsets, durations and shapes for each move are defined in
+`ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua`. Adjust the values in
+that module to tweak hitboxes without editing the move scripts themselves.
+
+## Move Settings
+
+Each move also has a dedicated configuration module for things like duration,
+hyper armor, guard break and hit count. For example, Party Table Kick's values
+can be edited in `ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua`.

--- a/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
@@ -13,6 +13,7 @@ local M1Event = CombatRemotes:WaitForChild("M1Event")
 
 -- 📦 Modules
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
+local MoveHitboxConfig = require(ReplicatedStorage.Modules.Config.MoveHitboxConfig)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local M1AnimationClient = require(ReplicatedStorage.Modules.Combat.M1AnimationClient)
@@ -68,9 +69,12 @@ function M1InputClient.OnInputBegan(input, gameProcessed)
                 task.delay(CombatConfig.M1.HitDelay, function()
                         if StunStatusClient.IsStunned() then return end
                         HitboxClient.CastHitbox(
-                                CombatConfig.M1.HitboxOffset,
-                                CombatConfig.M1.HitboxSize,
-                                CombatConfig.M1.HitboxDuration
+                                MoveHitboxConfig.M1.Offset,
+                                MoveHitboxConfig.M1.Size,
+                                MoveHitboxConfig.M1.Duration,
+                                nil,
+                                nil,
+                                MoveHitboxConfig.M1.Shape
                         )
                 end)
 

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -11,7 +11,8 @@ local StartEvent = CombatRemotes:WaitForChild("PartyTableKickStart")
 local HitEvent = CombatRemotes:WaitForChild("PartyTableKickHit")
 
 local Animations = require(ReplicatedStorage.Modules.Animations.Combat)
-local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
+local PartyTableKickConfig = require(ReplicatedStorage.Modules.Config.PartyTableKickConfig)
+local MoveHitboxConfig = require(ReplicatedStorage.Modules.Config.MoveHitboxConfig)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
@@ -47,7 +48,7 @@ local function playAnimation(animator, animId)
 end
 
 local function performMove()
-    local cfg = AbilityConfig.BlackLeg.PartyTableKick
+    local cfg = PartyTableKickConfig
     local char, humanoid, animator, hrp = getCharacter()
     if not char or not hrp or not humanoid then
         if DEBUG then print("[PartyTableKickClient] Invalid character state") end
@@ -80,7 +81,14 @@ local function performMove()
             if track then track:Stop() track:Destroy() end
             return
         end
-        HitboxClient.CastHitbox(cfg.HitboxOffset, cfg.HitboxSize, cfg.HitboxDuration, HitEvent, {i == cfg.Hits}, "Cylinder")
+        HitboxClient.CastHitbox(
+            MoveHitboxConfig.PartyTableKick.Offset,
+            MoveHitboxConfig.PartyTableKick.Size,
+            MoveHitboxConfig.PartyTableKick.Duration,
+            HitEvent,
+            {i == cfg.Hits},
+            MoveHitboxConfig.PartyTableKick.Shape
+        )
         if SoundConfig.Combat.BlackLeg and SoundConfig.Combat.BlackLeg.Hit and hrp then
             SoundUtils:PlaySpatialSound(SoundConfig.Combat.BlackLeg.Hit, hrp)
         end
@@ -128,7 +136,7 @@ function PartyTableKick.OnInputBegan(input, gp)
         if DEBUG then print("[PartyTableKickClient] Invalid combat tool") end
         return
     end
-    local cfg = AbilityConfig.BlackLeg.PartyTableKick
+    local cfg = PartyTableKickConfig
     if tick() - lastUse < (cfg.Cooldown or 0) then
         if DEBUG then print("[PartyTableKickClient] On cooldown") end
         return

--- a/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
@@ -1,18 +1,7 @@
 local AbilityConfig = {}
 
 AbilityConfig.BlackLeg = {
-    PartyTableKick = {
-        Hits = 16,
-        Duration = 4.5,
-        DamagePerHit = 3,
-        StunDuration = 0.5,
-        Startup = 0.4,
-        HyperArmor = false,
-        HitboxSize = Vector3.new(4,5,4),
-        HitboxOffset = CFrame.new(0,0,0),
-        HitboxDuration = 0.1,
-        Cooldown = 15,
-    }
+    PartyTableKick = require(script.Parent.PartyTableKickConfig),
 }
 
 return AbilityConfig

--- a/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
@@ -1,0 +1,17 @@
+local MoveHitboxConfig = {}
+
+MoveHitboxConfig.M1 = {
+    Size = Vector3.new(4, 5, 4),
+    Offset = CFrame.new(0, 0, -2.4),
+    Duration = 0.1,
+    Shape = "Block",
+}
+
+MoveHitboxConfig.PartyTableKick = {
+    Size = Vector3.new(4, 5, 4),
+    Offset = CFrame.new(0, 0, 0),
+    Duration = 0.1,
+    Shape = "Cylinder",
+}
+
+return MoveHitboxConfig

--- a/src/ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua
@@ -1,0 +1,15 @@
+local PartyTableKickConfig = {
+    Hits = 16,
+    Duration = 4.5,
+    DamagePerHit = 3,
+    StunDuration = 0.5,
+    Startup = 0.4,
+    HyperArmor = false,
+    GuardBreak = false,
+    HitboxSize = Vector3.new(4,5,4),
+    HitboxOffset = CFrame.new(0,0,0),
+    HitboxDuration = 0.1,
+    Cooldown = 15,
+}
+
+return PartyTableKickConfig

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -6,7 +6,7 @@ local CombatRemotes = Remotes:WaitForChild("Combat")
 local StartEvent = CombatRemotes:WaitForChild("PartyTableKickStart")
 local HitEvent = CombatRemotes:WaitForChild("PartyTableKickHit")
 
-local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
+local PartyTableKickConfig = require(ReplicatedStorage.Modules.Config.PartyTableKickConfig)
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local AnimationData = require(ReplicatedStorage.Modules.Animations.Combat)
 local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
@@ -88,7 +88,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
         return
     end
 
-    local cfg = AbilityConfig.BlackLeg.PartyTableKick
+    local cfg = PartyTableKickConfig
 
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character


### PR DESCRIPTION
## Summary
- allow Party Table Kick to have its own configuration module
- reference new `PartyTableKickConfig` from AbilityConfig
- update client and server logic to load the move config
- mention move settings in README

## Testing
- `rojo build default.project.json -o build.rbxlx` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684186b5e948832d8e0ea98e9f6503ba