### PR TITLE
Implement endlag and action lock for Party Table Kick

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ that module to tweak hitboxes without editing the move scripts themselves.
 ## Move Settings
 
 Each move also has a dedicated configuration module for things like duration,
-hyper armor, guard break and hit count. For example, Party Table Kick's values
+endlag, hyper armor, guard break and hit count. For example, Party Table Kick's values
 can be edited in `ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua`.

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -16,6 +16,7 @@ local MoveHitboxConfig = require(ReplicatedStorage.Modules.Config.MoveHitboxConf
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
+local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
@@ -56,6 +57,9 @@ local function performMove()
         return
     end
 
+    local prevSpeed = humanoid.WalkSpeed
+    humanoid.WalkSpeed = 3
+
     local animId = Animations.SpecialMoves.PartyTableKick
     local track = playAnimation(animator, animId)
     if DEBUG then print("[PartyTableKickClient] Animation started") end
@@ -68,6 +72,7 @@ local function performMove()
             if DEBUG then print("[PartyTableKickClient] Startup cancelled") end
             active = false
             if track then track:Stop() track:Destroy() end
+            humanoid.WalkSpeed = prevSpeed
             return
         end
         RunService.RenderStepped:Wait()
@@ -79,6 +84,7 @@ local function performMove()
             if DEBUG then print("[PartyTableKickClient] Move interrupted") end
             active = false
             if track then track:Stop() track:Destroy() end
+            humanoid.WalkSpeed = prevSpeed
             return
         end
         HitboxClient.CastHitbox(
@@ -98,6 +104,7 @@ local function performMove()
                 if not held or StunStatusClient.IsStunned() then
                     active = false
                     if track then track:Stop() track:Destroy() end
+                    humanoid.WalkSpeed = prevSpeed
                     return
                 end
                 RunService.RenderStepped:Wait()
@@ -106,6 +113,7 @@ local function performMove()
     end
     active = false
     if track then track:Stop() track:Destroy() end
+    humanoid.WalkSpeed = prevSpeed
     if DEBUG then print("[PartyTableKickClient] Move finished") end
 end
 
@@ -146,6 +154,11 @@ function PartyTableKick.OnInputBegan(input, gp)
     held = true
     active = true
     lastUse = tick()
+
+    MovementClient.StopSprint()
+    local lockTime = cfg.Startup + cfg.Duration + (cfg.Endlag or 0)
+    StunStatusClient.LockFor(lockTime)
+
     task.spawn(performMove)
 end
 

--- a/src/ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua
@@ -6,8 +6,7 @@ local PartyTableKickConfig = {
     Startup = 0.4,
     HyperArmor = false,
     GuardBreak = false,
-    HitboxSize = Vector3.new(4,5,4),
-    HitboxOffset = CFrame.new(0,0,0),
+    Endlag = 1,
     HitboxDuration = 0.1,
     Cooldown = 5,
 }


### PR DESCRIPTION
## Summary
- add `Endlag` to PartyTableKickConfig and remove hitbox size/offset
- allow Party Table Kick to walk at speed 3 and lock player actions until the move and endlag finish
- mention endlag in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418cf5e458832db352b5b6e64cfe58