### PR TITLE
Ensure move sounds play instantly

### DIFF
--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -161,20 +161,16 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             end
         end
 
-        task.delay(0.05, function()
-            local hitSfx = MoveSoundConfig.PartyTableKick and MoveSoundConfig.PartyTableKick.Hit
-            if hitSfx then
-                SoundUtils:PlaySpatialSound(hitSfx, hrp)
-            end
-            HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
-        end)
+        local hitSfx = MoveSoundConfig.PartyTableKick and MoveSoundConfig.PartyTableKick.Hit
+        if hitSfx then
+            SoundUtils:PlaySpatialSound(hitSfx, hrp)
+        end
+        HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
     end
     if not hitLanded then
         local missSfx = MoveSoundConfig.PartyTableKick and MoveSoundConfig.PartyTableKick.Miss
         if missSfx then
-            task.delay(0.05, function()
-                SoundUtils:PlaySpatialSound(missSfx, hrp)
-            end)
+            SoundUtils:PlaySpatialSound(missSfx, hrp)
         end
     end
     if DEBUG then print("[PartyTableKick] Hit sequence complete") end


### PR DESCRIPTION
## Summary
- remove hit sound and miss sound delays from Party Table Kick so delays only apply to M1 attacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a527a7a0832db5ebb31988273690