### PR TITLE
Fix early release lock duration

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -197,6 +197,8 @@ function PartyTableKick.OnInputEnded(input)
     else
         StopEvent:FireServer()
     end
+    -- Reduce attacker lock to just the endlag duration when the move is released early
+    StunStatusClient.ReduceLockTo(PartyTableKickConfig.Endlag or 0)
     if DEBUG then print("[PartyTableKickClient] Input ended") end
 end
 

--- a/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
@@ -7,6 +7,11 @@ local isStunned = false
 local serverLocked = false
 local localLockUntil = 0
 
+-- Helper to get remaining local lock duration
+local function getRemaining()
+    return math.max(0, localLockUntil - tick())
+end
+
 -- Getter functions (to be called)
 function StunStatusClient.IsStunned()
         return isStunned
@@ -30,6 +35,21 @@ end
 function StunStatusClient.LockFor(duration)
         if typeof(duration) ~= "number" or duration <= 0 then return end
         localLockUntil = math.max(localLockUntil, tick() + duration)
+end
+
+-- Force the local lock to end after the given duration if it would
+-- otherwise last longer. This cannot shorten server-applied locks.
+function StunStatusClient.ReduceLockTo(duration)
+    if typeof(duration) ~= "number" or duration < 0 then return end
+    local newEnd = tick() + duration
+    if newEnd < localLockUntil then
+        localLockUntil = newEnd
+    end
+end
+
+-- Expose remaining local lock duration for consumers
+function StunStatusClient.GetRemainingLock()
+    return getRemaining()
 end
 
 return StunStatusClient


### PR DESCRIPTION
## Summary
- add lock reduction helpers
- clamp party table kick lock to endlag when move is released early

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9df91fc832da25830d26d9be79a