### PR TITLE
Add Power Punch move and input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ that module to tweak hitboxes without editing the move scripts themselves.
 Each move also has a dedicated configuration module for things like duration,
 endlag, hyper armor, guard break and hit count. For example, Party Table Kick's values
 can be edited in `ReplicatedStorage/Modules/Config/PartyTableKickConfig.lua`.
+The Power Punch move uses `ReplicatedStorage/Modules/Config/PowerPunchConfig.lua` for its settings.

--- a/src/ReplicatedStorage/Modules/Animations/Combat.lua
+++ b/src/ReplicatedStorage/Modules/Animations/Combat.lua
@@ -37,7 +37,8 @@ Animation.Blocking = {
 }
 
 Animation.SpecialMoves = {
-        PartyTableKick = "rbxassetid://99204047574669",
+    PartyTableKick = "rbxassetid://99204047574669",
+    PowerPunch = "rbxassetid://70382508234278",
 }
 
 return Animation

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -1,0 +1,104 @@
+--ReplicatedStorage.Modules.Combat.Moves.PowerPunchClient
+local PowerPunch = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+local RunService = game:GetService("RunService")
+
+local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
+local StartEvent = CombatRemotes:WaitForChild("PowerPunchStart")
+local HitEvent = CombatRemotes:WaitForChild("PowerPunchHit")
+
+local Animations = require(ReplicatedStorage.Modules.Animations.Combat)
+local PowerPunchConfig = require(ReplicatedStorage.Modules.Config.PowerPunchConfig)
+local MoveHitboxConfig = require(ReplicatedStorage.Modules.Config.MoveHitboxConfig)
+local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
+local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
+local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
+local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
+local Config = require(ReplicatedStorage.Modules.Config.Config)
+
+local DEBUG = Config.GameSettings.DebugEnabled
+
+local KEY = Enum.KeyCode.R
+local active = false
+local lastUse = 0
+
+local function getCharacter()
+    local player = Players.LocalPlayer
+    local char = player.Character
+    if not char then return nil end
+    local humanoid = char:FindFirstChildOfClass("Humanoid")
+    local animator = humanoid and humanoid:FindFirstChildOfClass("Animator")
+    local hrp = char:FindFirstChild("HumanoidRootPart")
+    return char, humanoid, animator, hrp
+end
+
+local function playAnimation(animator, animId)
+    if not animator or not animId then return nil end
+    local anim = Instance.new("Animation")
+    anim.AnimationId = animId
+    local track = animator:LoadAnimation(anim)
+    track.Priority = Enum.AnimationPriority.Action
+    track:Play()
+    return track
+end
+
+local function performMove()
+    local cfg = PowerPunchConfig
+    local char, humanoid, animator, hrp = getCharacter()
+    if not char or not humanoid or not hrp then
+        active = false
+        if DEBUG then print("[PowerPunchClient] Invalid character state") end
+        return
+    end
+
+    playAnimation(animator, Animations.SpecialMoves.PowerPunch)
+    StartEvent:FireServer()
+
+    local startTime = tick()
+    while tick() - startTime < cfg.Startup do
+        RunService.RenderStepped:Wait()
+    end
+
+    HitboxClient.CastHitbox(
+        MoveHitboxConfig.PowerPunch.Offset,
+        MoveHitboxConfig.PowerPunch.Size,
+        MoveHitboxConfig.PowerPunch.Duration,
+        HitEvent,
+        {true},
+        MoveHitboxConfig.PowerPunch.Shape,
+        true
+    )
+
+    task.wait(cfg.Endlag)
+    active = false
+end
+
+function PowerPunch.OnInputBegan(input, gp)
+    if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
+    if active then return end
+    if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
+
+    local style = ToolController.GetEquippedStyleKey()
+    if style ~= "BasicCombat" then return end
+    if not ToolController.IsValidCombatTool() then return end
+
+    if tick() - lastUse < (PowerPunchConfig.Cooldown or 0) then return end
+
+    active = true
+    lastUse = tick()
+
+    MovementClient.StopSprint()
+    local lockTime = PowerPunchConfig.Startup + (PowerPunchConfig.Endlag or 0)
+    StunStatusClient.LockFor(lockTime)
+
+    task.spawn(performMove)
+end
+
+function PowerPunch.OnInputEnded()
+    -- move cannot be cancelled
+end
+
+return PowerPunch

--- a/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
@@ -14,4 +14,11 @@ MoveHitboxConfig.PartyTableKick = {
     Shape = "Cylinder",
 }
 
+MoveHitboxConfig.PowerPunch = {
+    Size = Vector3.new(4, 5, 5.5),
+    Offset = CFrame.new(0, 0, -3.5),
+    Duration = 0.1,
+    Shape = "Block",
+}
+
 return MoveHitboxConfig

--- a/src/ReplicatedStorage/Modules/Config/MoveSoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/MoveSoundConfig.lua
@@ -3,6 +3,9 @@ local MoveSoundConfig = {
         Hit = "rbxassetid://122809552011508",
         Miss = "rbxassetid://135883654541622",
         Loop = "rbxassetid://118537831520752",
+    },
+    PowerPunch = {
+        Hit = "rbxassetid://9117969717",
     }
 }
 

--- a/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
@@ -1,0 +1,12 @@
+local PowerPunchConfig = {
+    Damage = 8,
+    StunDuration = 2.0,
+    Startup = 2,
+    HyperArmor = true,
+    GuardBreak = true,
+    Endlag = 1.5,
+    HitboxDuration = 0.1,
+    Cooldown = 4,
+}
+
+return PowerPunchConfig

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -1,0 +1,142 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Debris = game:GetService("Debris")
+
+local Remotes = ReplicatedStorage:WaitForChild("Remotes")
+local CombatRemotes = Remotes:WaitForChild("Combat")
+local StartEvent = CombatRemotes:WaitForChild("PowerPunchStart")
+local HitEvent = CombatRemotes:WaitForChild("PowerPunchHit")
+
+local PowerPunchConfig = require(ReplicatedStorage.Modules.Config.PowerPunchConfig)
+local AnimationData = require(ReplicatedStorage.Modules.Animations.Combat)
+local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
+local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
+local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
+local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
+local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
+local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
+local Config = require(ReplicatedStorage.Modules.Config.Config)
+
+local DEBUG = Config.GameSettings.DebugEnabled
+
+local BlockEvent = CombatRemotes:WaitForChild("BlockEvent")
+
+local activeTracks = {}
+local function playAnimation(humanoid, animId)
+    if not animId or not humanoid then return end
+    local animator = humanoid:FindFirstChildOfClass("Animator")
+    if not animator then return end
+
+    animId = tostring(animId)
+    if not animId:match("^rbxassetid://") then
+        animId = "rbxassetid://" .. animId
+    end
+
+    local current = activeTracks[humanoid]
+    if current and current.IsPlaying then
+        current:Stop(0.05)
+    end
+
+    local anim = Instance.new("Animation")
+    anim.AnimationId = animId
+    local track = animator:LoadAnimation(anim)
+    track.Priority = Enum.AnimationPriority.Action
+    track:Play()
+
+    activeTracks[humanoid] = track
+
+    track.Stopped:Connect(function()
+        if activeTracks[humanoid] == track then
+            activeTracks[humanoid] = nil
+        end
+    end)
+end
+
+local function stopAnimation(humanoid)
+    local current = activeTracks[humanoid]
+    if current and current.IsPlaying then
+        current:Stop(0.05)
+    end
+    activeTracks[humanoid] = nil
+end
+
+StartEvent.OnServerEvent:Connect(function(player)
+    if DEBUG then print("[PowerPunch] StartEvent from", player.Name) end
+    local char = player.Character
+    local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+    if not humanoid then return end
+    if StunService:IsStunned(player) or StunService:IsAttackerLocked(player) then return end
+    local tool = char:FindFirstChildOfClass("Tool")
+    if not tool or tool.Name ~= "Basic Combat" then return end
+    playAnimation(humanoid, AnimationData.SpecialMoves.PowerPunch)
+end)
+
+HitEvent.OnServerEvent:Connect(function(player, targets)
+    if DEBUG then print("[PowerPunch] HitEvent from", player.Name) end
+    if typeof(targets) ~= "table" then return end
+
+    local char = player.Character
+    local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+    local hrp = char and char:FindFirstChild("HumanoidRootPart")
+    if not humanoid or not hrp then return end
+
+    local tool = char:FindFirstChildOfClass("Tool")
+    if not tool or tool.Name ~= "Basic Combat" then return end
+
+    local hitLanded = false
+
+    for _, enemyPlayer in ipairs(targets) do
+        local enemyChar = enemyPlayer.Character
+        local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
+        if not enemyHumanoid then continue end
+        if not StunService:CanBeHitBy(player, enemyPlayer) then continue end
+
+        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerPunchConfig.Damage, true)
+        if blockResult == "Perfect" then
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
+            BlockEvent:FireClient(enemyPlayer, false)
+            continue
+        elseif blockResult == "Damaged" then
+            continue
+        elseif blockResult == "Broken" then
+            StunService:ApplyStun(enemyHumanoid, BlockService.GetBlockBreakStunDuration(), false, player)
+            BlockEvent:FireClient(enemyPlayer, false)
+            continue
+        end
+
+        enemyHumanoid:TakeDamage(PowerPunchConfig.Damage)
+        hitLanded = true
+        HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
+        StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, true, player)
+
+        local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
+        if enemyRoot then
+            local dir = hrp.CFrame.LookVector
+            local knockback = CombatConfig.M1
+            local velocity = dir * (knockback.KnockbackDistance / knockback.KnockbackDuration)
+            velocity = Vector3.new(velocity.X, knockback.KnockbackLift, velocity.Z)
+
+            local bv = Instance.new("BodyVelocity")
+            bv.Velocity = velocity
+            bv.MaxForce = Vector3.new(1e5, 1e5, 1e5)
+            bv.P = 1500
+            bv.Parent = enemyRoot
+            Debris:AddItem(bv, knockback.KnockbackDuration)
+
+            enemyRoot.CFrame = CFrame.new(enemyRoot.Position, enemyRoot.Position - dir)
+
+            local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
+            if knockbackAnim then
+                playAnimation(enemyHumanoid, knockbackAnim)
+            end
+        end
+    end
+
+    if hitLanded then
+        local hitSfx = MoveSoundConfig.PowerPunch and MoveSoundConfig.PowerPunch.Hit
+        if hitSfx then
+            SoundUtils:PlaySpatialSound(hitSfx, hrp)
+        end
+    end
+end)
+
+return nil

--- a/src/ServerScriptService/Misc/RemoteSetup.server.lua
+++ b/src/ServerScriptService/Misc/RemoteSetup.server.lua
@@ -36,6 +36,8 @@ ensureEvent(combat, "JumpCooldownEvent")
 ensureEvent(combat, "PartyTableKickStart")
 ensureEvent(combat, "PartyTableKickHit")
 ensureEvent(combat, "PartyTableKickStop")
+ensureEvent(combat, "PowerPunchStart")
+ensureEvent(combat, "PowerPunchHit")
 
 -- Movement events
 local movement = ensureFolder(remotes, "Movement")

--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -81,6 +81,8 @@ end
 
 -- 🕹️ Route all input through controllers
 UserInputService.InputBegan:Connect(function(input, gameProcessed)
+        local typing = UserInputService:GetFocusedTextBox() ~= nil
+        gameProcessed = gameProcessed or typing
         if DEBUG and input.UserInputType == Enum.UserInputType.Keyboard then
                 print("[InputController] InputBegan:", input.KeyCode.Name, "GP:", gameProcessed)
         end
@@ -96,6 +98,8 @@ UserInputService.InputBegan:Connect(function(input, gameProcessed)
 end)
 
 UserInputService.InputEnded:Connect(function(input, gameProcessed)
+        local typing = UserInputService:GetFocusedTextBox() ~= nil
+        gameProcessed = gameProcessed or typing
         if DEBUG and input.UserInputType == Enum.UserInputType.Keyboard then
                 print("[InputController] InputEnded:", input.KeyCode.Name, "GP:", gameProcessed)
         end


### PR DESCRIPTION
## Summary
- add new `PowerPunch` move with its own config and scripts
- add hitbox and animation entries for the new move
- create remote events and server/client handlers for Power Punch
- prevent moves from triggering while typing in chat
- document Power Punch configuration
- update PowerPunch animation and hit sound

## Testing
- `rojo build default.project.json -o build.rbxl`


------
https://chatgpt.com/codex/tasks/task_e_6841be7a9048832db6045acd817ca5ca