### PR TITLE
Fix PowerPunch hitbox VFX and knockback

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
@@ -131,6 +131,8 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
                         end
                 end
         end)
+
+        return hitbox
 end
 
 return HitboxClient

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -50,8 +50,8 @@ local function playAnimation(animator, animId)
     return track
 end
 
-local function playVFX(hrp)
-    if not hrp then return end
+local function playVFX(parentPart)
+    if not parentPart then return end
     local emitter = Instance.new("ParticleEmitter")
     emitter.Texture = "rbxassetid://14049479051"
     emitter.LightEmission = 1
@@ -63,7 +63,7 @@ local function playVFX(hrp)
         NumberSequenceKeypoint.new(0, 2),
         NumberSequenceKeypoint.new(1, 0)
     })
-    emitter.Parent = hrp
+    emitter.Parent = parentPart
     emitter:Emit(12)
     Debris:AddItem(emitter, 1)
 end
@@ -97,9 +97,7 @@ local function performMove()
     prevJumpPower = nil
     currentHumanoid = nil
 
-    playVFX(hrp)
-    
-    HitboxClient.CastHitbox(
+    local hitbox = HitboxClient.CastHitbox(
         MoveHitboxConfig.PowerPunch.Offset,
         MoveHitboxConfig.PowerPunch.Size,
         MoveHitboxConfig.PowerPunch.Duration,
@@ -109,6 +107,10 @@ local function performMove()
         true,
         5
     )
+
+    if hitbox then
+        playVFX(hitbox)
+    end
 
     task.wait(cfg.Endlag)
     active = false

--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -137,7 +137,11 @@ function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker)
                         targetHumanoid.Jump = false
                         if hrp then
                                 local v = hrp.AssemblyLinearVelocity
-                                hrp.AssemblyLinearVelocity = Vector3.new(0, v.Y, 0)
+                                -- Preserve applied knockback forces by not
+                                -- zeroing horizontal velocity when a BodyVelocity is present
+                                if not hrp:FindFirstChildOfClass("BodyVelocity") then
+                                        hrp.AssemblyLinearVelocity = Vector3.new(0, v.Y, 0)
+                                end
                                 hrp.AssemblyAngularVelocity = Vector3.new(0,0,0)
                         end
                 end

--- a/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/MoveHitboxConfig.lua
@@ -17,7 +17,7 @@ MoveHitboxConfig.PartyTableKick = {
 MoveHitboxConfig.PowerPunch = {
     Size = Vector3.new(4, 5, 5.5),
     Offset = CFrame.new(0, 0, -3.5),
-    Duration = 1,
+    Duration = 0.5,
     Shape = "Block",
 }
 

--- a/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
@@ -1,11 +1,11 @@
 local PowerPunchConfig = {
     Damage = 8,
     StunDuration = 2.0,
-    Startup = 1.5,
+    Startup = 1.0,
     HyperArmor = true,
     GuardBreak = true,
     Endlag = 1.5,
-    HitboxDuration = 1,
+    HitboxDuration = 0.5,
     Cooldown = 4,
 }
 

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -158,6 +158,11 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
                 Debris:AddItem(bv, knockback.KnockbackDuration)
 
                 enemyRoot.CFrame = CFrame.new(enemyRoot.Position, enemyRoot.Position - dir)
+
+                local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
+                if knockbackAnim then
+                    playAnimation(enemyHumanoid, knockbackAnim)
+                end
             end
         end
 


### PR DESCRIPTION
## Summary
- reduce PowerPunch startup and hitbox duration
- keep horizontal velocity when body velocity is present in StunService
- play knockback animation for PartyTableKick final hit
- return created hitbox from `HitboxClient.CastHitbox`
- spawn PowerPunch VFX on the traveling hitbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d88d3138832d9d7ce30737a564d8