### PR TITLE
Fix move sound replication and attack timing

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
@@ -74,7 +74,8 @@ function M1InputClient.OnInputBegan(input, gameProcessed)
                                 MoveHitboxConfig.M1.Duration,
                                 nil,
                                 nil,
-                                MoveHitboxConfig.M1.Shape
+                                MoveHitboxConfig.M1.Shape,
+                                true -- ensure miss is reported to server
                         )
                 end)
 

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -18,8 +18,7 @@ local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClie
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
-local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
-local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
+
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -30,7 +29,6 @@ local held = false
 local lastUse = 0
 
 local currentTrack
-local currentSound
 local currentHumanoid
 local prevWalkSpeed
 
@@ -60,10 +58,6 @@ local function cleanup()
         currentTrack:Destroy()
         currentTrack = nil
     end
-    if currentSound then
-        currentSound:Destroy()
-        currentSound = nil
-    end
     if currentHumanoid and prevWalkSpeed then
         currentHumanoid.WalkSpeed = prevWalkSpeed
     end
@@ -88,14 +82,6 @@ local function performMove()
     if DEBUG then print("[PartyTableKickClient] Animation started") end
     StartEvent:FireServer()
     if DEBUG then print("[PartyTableKickClient] StartEvent fired") end
-
-    local loopSound
-    if hrp and MoveSoundConfig.PartyTableKick and MoveSoundConfig.PartyTableKick.Loop then
-        loopSound = SoundUtils:PlayLoopingSpatialSound(MoveSoundConfig.PartyTableKick.Loop, hrp)
-    end
-
-    currentSound = loopSound
-
     local function endMove()
         if not active then return end
         active = false

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -91,12 +91,7 @@ local function performMove()
         RunService.RenderStepped:Wait()
     end
 
-    humanoid.WalkSpeed = prevWalkSpeed
-    humanoid.JumpPower = prevJumpPower
-    prevWalkSpeed = nil
-    prevJumpPower = nil
-    currentHumanoid = nil
-
+    -- Cast the hitbox while movement is still locked
     local hitbox = HitboxClient.CastHitbox(
         MoveHitboxConfig.PowerPunch.Offset,
         MoveHitboxConfig.PowerPunch.Size,
@@ -113,6 +108,13 @@ local function performMove()
     end
 
     task.wait(cfg.Endlag)
+
+    -- Restore movement after endlag finishes
+    humanoid.WalkSpeed = prevWalkSpeed
+    humanoid.JumpPower = prevJumpPower
+    prevWalkSpeed = nil
+    prevJumpPower = nil
+    currentHumanoid = nil
     active = false
 end
 

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -22,6 +22,7 @@ local DEBUG = Config.GameSettings.DebugEnabled
 local BlockEvent = CombatRemotes:WaitForChild("BlockEvent")
 
 local activeTracks = {}
+local activeLoopSounds = {}
 
 local function playAnimation(humanoid, animId)
     if not animId or not humanoid then return end
@@ -80,6 +81,12 @@ StartEvent.OnServerEvent:Connect(function(player)
     end
     playAnimation(humanoid, AnimationData.SpecialMoves.PartyTableKick)
     if DEBUG then print("[PartyTableKick] Animation triggered") end
+    local hrp = char:FindFirstChild("HumanoidRootPart")
+    local loopId = MoveSoundConfig.PartyTableKick and MoveSoundConfig.PartyTableKick.Loop
+    if hrp and loopId then
+        local sound = SoundUtils:PlayLoopingSpatialSound(loopId, hrp)
+        activeLoopSounds[player] = sound
+    end
 end)
 
 HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
@@ -187,5 +194,10 @@ StopEvent.OnServerEvent:Connect(function(player)
     if humanoid then
         stopAnimation(humanoid)
         if DEBUG then print("[PartyTableKick] Animation stopped for", player.Name) end
+    end
+    local sound = activeLoopSounds[player]
+    if sound then
+        sound:Destroy()
+        activeLoopSounds[player] = nil
     end
 end)


### PR DESCRIPTION
## Summary
- ensure M1 hitboxes always notify server for miss sounds
- lock movement for the full Power Punch sequence
- replicate Party Table Kick loop sound to all players
- remove client-side loop sound handling

## Testing
- `rojo build default.project.json -o test.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841df56c48c832da8b55dd37657382e