### PR TITLE
Add player health bar management

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -1,0 +1,66 @@
+--ReplicatedStorage.Modules.Client.PlayerGuiManager
+
+local PlayerGuiManager = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local player = Players.LocalPlayer
+local PlayerGui = player:WaitForChild("PlayerGui")
+
+local screenGui
+local healthBar
+local connection
+
+-- Clone the existing PlayerGUI from ReplicatedStorage.Assets
+local function ensureGui()
+    if screenGui then return end
+
+    local assets = ReplicatedStorage:WaitForChild("Assets")
+    local template = assets:WaitForChild("PlayerGUI")
+
+    screenGui = PlayerGui:FindFirstChild("PlayerGUI")
+    if not screenGui then
+        screenGui = template:Clone()
+        screenGui.Name = "PlayerGUI"
+        screenGui.Parent = PlayerGui
+    end
+    screenGui.ResetOnSpawn = false
+    screenGui.Enabled = false
+
+    local guiFrame = screenGui:WaitForChild("GUI")
+    healthBar = guiFrame:WaitForChild("HealthBarBGMiddle"):WaitForChild("HealthBar")
+end
+
+function PlayerGuiManager.Show()
+    ensureGui()
+    screenGui.Enabled = true
+end
+
+function PlayerGuiManager.Hide()
+    if screenGui then
+        screenGui.Enabled = false
+    end
+end
+
+function PlayerGuiManager.BindHumanoid(humanoid)
+    if connection then
+        connection:Disconnect()
+        connection = nil
+    end
+
+    if not humanoid then return end
+
+    ensureGui()
+
+    local function update()
+        local ratio = humanoid.Health / humanoid.MaxHealth
+        healthBar.Size = UDim2.new(math.clamp(ratio, 0, 1), 0, 1, 0)
+    end
+
+    update()
+    connection = humanoid.HealthChanged:Connect(update)
+end
+
+return PlayerGuiManager
+

--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -33,6 +33,8 @@ local MenuLogic       = require(MenuCfgs:WaitForChild("MenuLogic"))
 local LoadingManager  = require(MenuCfgs:WaitForChild("LoadingManager"))
 local CameraManager   = require(MenuCfgs:WaitForChild("CameraManager"))
 local MenuGlobalCfg   = require(MenuCfgs:WaitForChild("MenuGlobalCfg"))
+local PlayerGuiManager = require(ReplicatedStorage.Modules.Client.PlayerGuiManager)
+PlayerGuiManager.Hide()
 
 -- 🔁 Remotes
 local Remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -98,8 +100,11 @@ local function spawnAndFollow(toolName)
 		return
 	end
 
-	local humanoid = char:WaitForChild("Humanoid")
-	local hrp = char:WaitForChild("HumanoidRootPart")
+        local humanoid = char:WaitForChild("Humanoid")
+        local hrp = char:WaitForChild("HumanoidRootPart")
+
+        PlayerGuiManager.BindHumanoid(humanoid)
+        PlayerGuiManager.Show()
 
 	local camera = workspace.CurrentCamera
 	camera.CameraSubject = humanoid
@@ -125,10 +130,11 @@ end
 
 -- 🎬 Initialize main menu
 local function initMainMenu()
-	print("[MainMenuClient] Initializing Main Menu")
-	CameraManager.ApplyMenuCamera()
-	setButtonsEnabled(true)
-	PlayerEnteredMenu:FireServer()
+        print("[MainMenuClient] Initializing Main Menu")
+        CameraManager.ApplyMenuCamera()
+        PlayerGuiManager.Hide()
+        setButtonsEnabled(true)
+        PlayerEnteredMenu:FireServer()
 
 	MenuLogic.ShowMainMenu(function(toolName)
 		spawnAndFollow(toolName)
@@ -137,8 +143,9 @@ end
 
 -- ⏮ Return to menu
 ReturnToMenuEvent.OnClientEvent:Connect(function()
-	showTransitionScreen("Returning to menu...")
-	setButtonsEnabled(false)
+        showTransitionScreen("Returning to menu...")
+        PlayerGuiManager.Hide()
+        setButtonsEnabled(false)
 
 	local duration = MenuGlobalCfg.TransitionScreen and MenuGlobalCfg.TransitionScreen.Duration or 1
 	task.delay(duration, function()


### PR DESCRIPTION
## Summary
- add a PlayerGuiManager module that builds a health bar GUI and updates it using the humanoid's health
- show the PlayerGUI when the player spawns and hide it while in menu
- hook the new manager into the main menu client

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6841e03dfa04832da32fb17a9c27c090