### PR TITLE
Fix knockback direction for special moves

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -92,12 +92,13 @@ local function performMove()
     end
 
     -- Cast the hitbox while movement is still locked
+    local dir = hrp.CFrame.LookVector
     local hitbox = HitboxClient.CastHitbox(
         MoveHitboxConfig.PowerPunch.Offset,
         MoveHitboxConfig.PowerPunch.Size,
         MoveHitboxConfig.PowerPunch.Duration,
         HitEvent,
-        {true},
+        {dir},
         MoveHitboxConfig.PowerPunch.Shape,
         true,
         5

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -152,7 +152,9 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             if DEBUG then print("[PartyTableKick] Final hit on", enemyPlayer.Name) end
             local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
             if enemyRoot then
-                local dir = hrp.CFrame.LookVector
+                local rel = enemyRoot.Position - hrp.Position
+                rel = Vector3.new(rel.X, 0, rel.Z)
+                local dir = rel.Magnitude > 0 and rel.Unit or hrp.CFrame.LookVector
                 local knockback = CombatConfig.M1
                 local velocity = dir * (knockback.KnockbackDistance / knockback.KnockbackDuration)
                 velocity = Vector3.new(velocity.X, knockback.KnockbackLift, velocity.Z)

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -72,7 +72,7 @@ StartEvent.OnServerEvent:Connect(function(player)
     VFXEvent:FireAllClients(player)
 end)
 
-HitEvent.OnServerEvent:Connect(function(player, targets)
+HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     if DEBUG then print("[PowerPunch] HitEvent from", player.Name) end
     if typeof(targets) ~= "table" then return end
 
@@ -112,9 +112,9 @@ HitEvent.OnServerEvent:Connect(function(player, targets)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
-            local dir = hrp.CFrame.LookVector
+            local kbDir = typeof(dir) == "Vector3" and dir or hrp.CFrame.LookVector
             local knockback = CombatConfig.M1
-            local velocity = dir * (knockback.KnockbackDistance / knockback.KnockbackDuration)
+            local velocity = kbDir * (knockback.KnockbackDistance / knockback.KnockbackDuration)
             velocity = Vector3.new(velocity.X, knockback.KnockbackLift, velocity.Z)
 
             local bv = Instance.new("BodyVelocity")
@@ -124,7 +124,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets)
             bv.Parent = enemyRoot
             Debris:AddItem(bv, knockback.KnockbackDuration)
 
-            enemyRoot.CFrame = CFrame.new(enemyRoot.Position, enemyRoot.Position - dir)
+            enemyRoot.CFrame = CFrame.new(enemyRoot.Position, enemyRoot.Position - kbDir)
 
             local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
             if knockbackAnim then


### PR DESCRIPTION
## Summary
- make Power Punch send hitbox direction to the server
- apply knockback based on provided direction on the server
- knock back Party Table Kick targets away from the attacker

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5aac0a4832d86a4ac4d50d4b133