### PR TITLE
Fix power punch knockback

### DIFF
--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -114,6 +114,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
+            enemyRoot:SetNetworkOwner(nil)
             local kbDir = typeof(dir) == "Vector3" and dir or hrp.CFrame.LookVector
             local knockback = CombatConfig.M1
             local velocity = kbDir * (knockback.KnockbackDistance / knockback.KnockbackDuration)


### PR DESCRIPTION
## Summary
- ensure server owns enemy root when applying Power Punch knockback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e7e6754c832dabed832dce776d0a