### PR TITLE
Fix PowerPunch config syntax error

### DIFF
--- a/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/PowerPunchConfig.lua
@@ -8,5 +8,6 @@ local PowerPunchConfig = {
     HitboxDuration = 0.5,
     HitboxDistance = 5,
     Cooldown = 4,
+}
 
 return PowerPunchConfig


### PR DESCRIPTION
## Summary
- fix missing closing brace in `PowerPunchConfig`

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_6841f2174620832d8ab0d572d13aef68