### PR TITLE
Fix PowerPunch knockback

### DIFF
--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -119,8 +119,6 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
             local velocity = kbDir * (knockback.KnockbackDistance / knockback.KnockbackDuration)
             velocity = Vector3.new(velocity.X, knockback.KnockbackLift, velocity.Z)
 
-            enemyRoot:SetNetworkOwner(nil)
-
             local bv = Instance.new("BodyVelocity")
             bv.Velocity = velocity
             bv.MaxForce = Vector3.new(1e5, 1e5, 1e5)


### PR DESCRIPTION
## Summary
- remove SetNetworkOwner call when applying knockback for Power Punch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f2dfa92c832d8bba413652da7a36