### PR TITLE
Fix block vfx persisting

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -86,13 +86,13 @@ end)
 BlockVFXEvent.OnClientEvent:Connect(function(blockPlayer, active)
        if blockPlayer == player then return end
        if typeof(active) ~= "boolean" then return end
+
        local char = blockPlayer.Character
        local hrp = char and char:FindFirstChild("HumanoidRootPart")
-       if not hrp then return end
-
        local vfx = otherVFX[blockPlayer]
+
        if active then
-               if not vfx then
+               if hrp and not vfx then
                        vfx = BlockVFX.Create(hrp)
                        otherVFX[blockPlayer] = vfx
                end


### PR DESCRIPTION
## Summary
- ensure block VFX is removed when players stop blocking even if HRP not found

## Testing
- `echo "No tests present" && true`


------
https://chatgpt.com/codex/tasks/task_e_68420048297c832d8d212bea5fabb33d