### PR TITLE
Fix network owner reset for knockback

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
@@ -52,6 +52,7 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
     lift = lift or 3
 
     local playerOwner = Players:GetPlayerFromCharacter(humanoid.Parent)
+    local originalOwner = root:GetNetworkOwner()
 
     -- Server controls physics during knockback
     root:SetNetworkOwner(nil)
@@ -80,7 +81,7 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
     -- Restore network ownership after knockback duration
     task.delay(duration, function()
         if root.Parent then
-            root:SetNetworkOwner(playerOwner)
+            root:SetNetworkOwner(originalOwner or playerOwner)
         end
     end)
 end


### PR DESCRIPTION
## Summary
- preserve original network owner in `KnockbackService`

## Testing
- `git commit -m "Preserve original network owner during knockback"`

------
https://chatgpt.com/codex/tasks/task_e_6842178d6870832d95d7f4f3a6d296c4