### PR TITLE
Fix knockback movement

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
@@ -56,6 +56,8 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
 
     -- Server controls physics during knockback
     root:SetNetworkOwner(nil)
+    -- Mark knockback active so other systems don't zero velocity
+    root:SetAttribute("KnockbackActive", true)
 
     local speed = distance / duration
     local knockVelocity = Vector3.new(direction.X * speed, lift, direction.Z * speed)
@@ -70,6 +72,7 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
     task.delay(duration, function()
         if root.Parent then
             root:SetNetworkOwner(originalOwner or playerOwner)
+            root:SetAttribute("KnockbackActive", nil)
         end
     end)
 end

--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -140,7 +140,8 @@ function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker)
                                -- Preserve applied knockback forces by not
                                -- zeroing horizontal velocity when a knockback force is present
                                if not hrp:FindFirstChildOfClass("BodyVelocity")
-                                       and not hrp:FindFirstChildOfClass("VectorForce") then
+                                       and not hrp:FindFirstChildOfClass("VectorForce")
+                                       and not hrp:GetAttribute("KnockbackActive") then
                                        hrp.AssemblyLinearVelocity = Vector3.new(0, v.Y, 0)
                                end
                                 hrp.AssemblyAngularVelocity = Vector3.new(0,0,0)


### PR DESCRIPTION
## Summary
- preserve knockback velocity during stun when the server controls the character by marking the root part with a `KnockbackActive` attribute

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421fb288ec832da214a497f947eb34