### PR TITLE
Add background music manager

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/MusicManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/MusicManager.lua
@@ -1,0 +1,63 @@
+--ReplicatedStorage.Modules.Client.MusicManager
+
+local MusicManager = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local player = Players.LocalPlayer
+local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
+
+local currentSound
+
+local function playSound(id: string, looped: boolean)
+    if not id or id == "" then return nil end
+    if not id:match("^rbxassetid://") then
+        id = "rbxassetid://" .. id
+    end
+
+    if currentSound then
+        currentSound:Stop()
+        currentSound:Destroy()
+        currentSound = nil
+    end
+
+    local sound = Instance.new("Sound")
+    sound.SoundId = id
+    sound.Volume = 0.5
+    sound.Looped = looped or false
+    sound.Parent = workspace
+    sound:Play()
+
+    currentSound = sound
+    return sound
+end
+
+function MusicManager.PlayMenuMusic()
+    playSound(SoundConfig.Music.MainMenuMusic, true)
+end
+
+function MusicManager.StartGameplayMusic()
+    local pool = SoundConfig.Music.MusicPool
+    if not pool or #pool == 0 then return end
+
+    local function playRandom()
+        local index = math.random(1, #pool)
+        local track = playSound(pool[index], false)
+        if track then
+            track.Ended:Once(playRandom)
+        end
+    end
+
+    playRandom()
+end
+
+function MusicManager.Stop()
+    if currentSound then
+        currentSound:Stop()
+        currentSound:Destroy()
+        currentSound = nil
+    end
+end
+
+return MusicManager

--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -34,6 +34,7 @@ local LoadingManager  = require(MenuCfgs:WaitForChild("LoadingManager"))
 local CameraManager   = require(MenuCfgs:WaitForChild("CameraManager"))
 local MenuGlobalCfg   = require(MenuCfgs:WaitForChild("MenuGlobalCfg"))
 local PlayerGuiManager = require(ReplicatedStorage.Modules.Client.PlayerGuiManager)
+local MusicManager    = require(ReplicatedStorage.Modules.Client.MusicManager)
 PlayerGuiManager.Hide()
 
 -- 🔁 Remotes
@@ -86,12 +87,12 @@ local function spawnAndFollow(toolName)
 	local duration = MenuGlobalCfg.TransitionScreen and MenuGlobalCfg.TransitionScreen.Duration or 1
 	task.delay(duration, hideTransitionScreen)
 
-	PlayerLeftMenu:FireServer()
-	SpawnRequestEvent:FireServer(toolName)
-	MenuLogic.HideMenu()
-	setButtonsEnabled(false)
+        PlayerLeftMenu:FireServer()
+        SpawnRequestEvent:FireServer(toolName)
+        MenuLogic.HideMenu()
+        setButtonsEnabled(false)
 
-	player.CharacterAdded:Wait()
+        player.CharacterAdded:Wait()
 	task.wait(0.25)
 
 	local char = player.Character
@@ -120,16 +121,17 @@ local function spawnAndFollow(toolName)
 	-- 🔄 Enforce camera following for a short time
 	local startTime = tick()
 	local conn
-	conn = RunService.RenderStepped:Connect(function()
-		if tick() - startTime > 2 then
-			conn:Disconnect()
-		else
-			camera.CameraSubject = humanoid
-			camera.CameraType = Enum.CameraType.Custom
-		end
-	end)
+        conn = RunService.RenderStepped:Connect(function()
+                if tick() - startTime > 2 then
+                        conn:Disconnect()
+                else
+                        camera.CameraSubject = humanoid
+                        camera.CameraType = Enum.CameraType.Custom
+                end
+        end)
 
-	setButtonsEnabled(true)
+        MusicManager.StartGameplayMusic()
+        setButtonsEnabled(true)
 end
 
 -- 🎬 Initialize main menu
@@ -138,6 +140,7 @@ local function initMainMenu()
         CameraManager.ApplyMenuCamera()
         PlayerGuiManager.Hide()
         setButtonsEnabled(true)
+        MusicManager.PlayMenuMusic()
         PlayerEnteredMenu:FireServer()
 
 	MenuLogic.ShowMainMenu(function(toolName)
@@ -151,14 +154,15 @@ ReturnToMenuEvent.OnClientEvent:Connect(function()
         PlayerGuiManager.Hide()
         setButtonsEnabled(false)
 
-	local duration = MenuGlobalCfg.TransitionScreen and MenuGlobalCfg.TransitionScreen.Duration or 1
-	task.delay(duration, function()
-		CameraManager.ClearMenuCamera()
-		task.wait(0.1)
-		CameraManager.ApplyMenuCamera()
-		initMainMenu()
-		hideTransitionScreen()
-	end)
+        local duration = MenuGlobalCfg.TransitionScreen and MenuGlobalCfg.TransitionScreen.Duration or 1
+        task.delay(duration, function()
+                CameraManager.ClearMenuCamera()
+                task.wait(0.1)
+                CameraManager.ApplyMenuCamera()
+                MusicManager.PlayMenuMusic()
+                initMainMenu()
+                hideTransitionScreen()
+        end)
 end)
 
 -- 🚀 Begin game


### PR DESCRIPTION
## Summary
- add `MusicManager` to handle menu and gameplay music
- hook menu client to play menu music and random gameplay tracks

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6842d69af0c8832d89f8e2fe294fc269