### PR TITLE
Fix PowerPunch knockback

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
@@ -59,6 +59,12 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
 
     humanoid.PlatformStand = false
     root.Anchored = false
+
+    local previousOwner = nil
+    if root.GetNetworkOwner then
+        previousOwner = root:GetNetworkOwner()
+    end
+
     root:SetNetworkOwner(nil)
     clearForces(root)
 
@@ -80,6 +86,15 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
     task.delay(duration, function()
         if root.Parent then
             root:SetAttribute("KnockbackActive", nil)
+            if previousOwner then
+                root:SetNetworkOwner(previousOwner)
+            else
+                local char = humanoid.Parent
+                local player = char and Players:GetPlayerFromCharacter(char)
+                if player then
+                    root:SetNetworkOwner(player)
+                end
+            end
             if DEBUG then
                 print("[KnockbackService] Knockback ended for", humanoid.Parent.Name)
             end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -106,16 +106,18 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, true, player, true)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
-        local knockback = CombatConfig.M1
-        KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-            DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
-            AttackerRoot = hrp,
-            TargetRoot = enemyRoot,
-            HitboxDirection = typeof(dir) == "Vector3" and dir or nil,
-            Distance = knockback.KnockbackDistance,
-            Duration = knockback.KnockbackDuration,
-            Lift = knockback.KnockbackLift,
-        })
+        if enemyRoot then
+            local knockback = CombatConfig.M1
+            KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
+                DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
+                AttackerRoot = hrp,
+                TargetRoot = enemyRoot,
+                HitboxDirection = typeof(dir) == "Vector3" and dir or nil,
+                Distance = knockback.KnockbackDistance,
+                Duration = knockback.KnockbackDuration,
+                Lift = knockback.KnockbackLift,
+            })
+        end
 
         local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
         if knockbackAnim then


### PR DESCRIPTION
## Summary
- restore network ownership after knockback ends
- apply directional knockback to PowerPunch

## Testing
- `rojo build default.project.json -o build.rbxl`

------
https://chatgpt.com/codex/tasks/task_e_6842e1750ec8832dae56c7d351963f02