### PR TITLE
Improve PowerPunch knockback

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
@@ -44,7 +44,17 @@ end
 -- ✅ Main cast function (runs hit detection client-side)
 -- Optional remoteEvent and extraArgs allow reusing this hitbox logic for
 -- other attacks. If remoteEvent is nil, the default HitConfirmEvent is used.
-function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extraArgs, shape, fireOnMiss, travelDistance)
+function HitboxClient.CastHitbox(
+    offsetCFrame,
+    size,
+    duration,
+    remoteEvent,
+    extraArgs,
+    shape,
+    fireOnMiss,
+    travelDistance,
+    fireOnHit
+)
 	local player = Players.LocalPlayer
 	local char = player.Character
 	if not char then return end
@@ -52,8 +62,8 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
 	local hrp = char:FindFirstChild("HumanoidRootPart")
 	if not hrp then return end
 
-        local hitbox = createWeldedHitbox(hrp, offsetCFrame, size, duration, shape)
-        if not hitbox then return end
+    local hitbox = createWeldedHitbox(hrp, offsetCFrame, size, duration, shape)
+    if not hitbox then return end
 
         local originCF = hitbox.CFrame
         local dir = hrp.CFrame.LookVector
@@ -63,7 +73,7 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
                 hitbox.Anchored = true
         end
 
-	local alreadyHit = {}
+    local alreadyHit = {}
 	local overlapParams = OverlapParams.new()
 	overlapParams.FilterType = Enum.RaycastFilterType.Exclude
 	overlapParams.FilterDescendantsInstances = { char }
@@ -94,17 +104,23 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
                                 end
                         end
 
-                        if #playerTargets > 0 or fireOnMiss then
-                                if remoteEvent then
-                                        remoteEvent:FireServer(playerTargets, table.unpack(extraArgs or {}))
-                                else
-                                        local comboIndex = CombatConfig._lastUsedComboIndex or 1
-                                        local isFinal = comboIndex == CombatConfig.M1.ComboHits
-                                        HitConfirmEvent:FireServer(playerTargets, comboIndex, isFinal)
+                        if fireOnHit then
+                                if #playerTargets == 0 and fireOnMiss and remoteEvent then
+                                        remoteEvent:FireServer({}, table.unpack(extraArgs or {}))
+                                end
+                        else
+                                if #playerTargets > 0 or fireOnMiss then
+                                        if remoteEvent then
+                                                remoteEvent:FireServer(playerTargets, table.unpack(extraArgs or {}))
+                                        else
+                                                local comboIndex = CombatConfig._lastUsedComboIndex or 1
+                                                local isFinal = comboIndex == CombatConfig.M1.ComboHits
+                                                HitConfirmEvent:FireServer(playerTargets, comboIndex, isFinal)
+                                        end
                                 end
                         end
-                       return
-               end
+                        return
+                end
 
                 local parts = Workspace:GetPartBoundsInBox(hitbox.CFrame, hitbox.Size, overlapParams)
                 for _, part in ipairs(parts) do
@@ -113,6 +129,7 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
                         local otherPlayer = model and Players:GetPlayerFromCharacter(model)
 
                         if humanoid and otherPlayer and otherPlayer ~= player then
+                                local newHit = false
                                 if shape == "Cylinder" then
                                         local root = model:FindFirstChild("HumanoidRootPart")
                                         if root then
@@ -121,12 +138,19 @@ function HitboxClient.CastHitbox(offsetCFrame, size, duration, remoteEvent, extr
                                                 local dz = root.Position.Z - center.Z
                                                 local radius = hitbox.Size.X * 0.5
                                                 local height = hitbox.Size.Y
-                                                if math.sqrt(dx*dx + dz*dz) <= radius and math.abs(root.Position.Y - center.Y) <= height * 0.5 then
-                                                        alreadyHit[humanoid] = true
+                                                if math.sqrt(dx * dx + dz * dz) <= radius and math.abs(root.Position.Y - center.Y) <= height * 0.5 then
+                                                        newHit = true
                                                 end
                                         end
                                 else
+                                        newHit = true
+                                end
+
+                                if newHit and not alreadyHit[humanoid] then
                                         alreadyHit[humanoid] = true
+                                        if fireOnHit and remoteEvent then
+                                                remoteEvent:FireServer({ otherPlayer }, table.unpack(extraArgs or {}))
+                                        end
                                 end
                         end
                 end

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -103,7 +103,8 @@ local function performMove()
         {dir},
         MoveHitboxConfig.PowerPunch.Shape,
         true,
-        PowerPunchConfig.HitboxDistance
+        PowerPunchConfig.HitboxDistance,
+        true
     )
 
     if hitbox then


### PR DESCRIPTION
## Summary
- support firing hit events immediately in `HitboxClient`
- use new option for PowerPunch to knock back enemies as soon as they are touched

## Testing
- `rojo build default.project.json -o build.rbxl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e798a0a8832d96b2e8d66022d3fd