### PR TITLE
Fix PowerPunch knockback and stun

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,18 @@ Move settings such as damage, stun duration and cooldown are defined in
 `ReplicatedStorage/Modules/Config/AbilityConfig.lua` under each combat style.
 For example, Party Table Kick's values live at `AbilityConfig.BlackLeg.PartyTableKick`
 and Power Punch uses `AbilityConfig.BasicCombat.PowerPunch`.
+
+## Development Setup
+
+This project uses [Rojo](https://github.com/rojo-rbx/rojo) to build place files. The recommended way to install Rojo is with [Aftman](https://github.com/LPGhatguy/aftman).
+
+1. Download the Aftman binary for your platform from the [GitHub releases page](https://github.com/LPGhatguy/aftman/releases) and run `./aftman self-install`.
+2. In this repository, run `aftman install` to install the tools listed in `aftman.toml` (including Rojo).
+
+After installation you can build the project with:
+
+```sh
+rojo build default.project.json -o game.rbxlx
+```
+
+This is the same command used in tests to verify that the project compiles correctly.

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -103,7 +103,6 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         enemyHumanoid:TakeDamage(PowerPunchConfig.Damage)
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
-        StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, true, player, true)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
@@ -118,6 +117,8 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
                 Lift = knockback.KnockbackLift,
             })
         end
+
+        StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, false, player, true)
 
         local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
         if knockbackAnim then


### PR DESCRIPTION
## Summary
- ensure PowerPunch applies knockback before stunning
- show the stun animation so enemies visibly freeze
- document how to install Rojo with Aftman

## Testing
- `rojo build default.project.json -o /tmp/game.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_6842ea9c1944832da84f757978740264