### PR TITLE
Implement hitbox travel knockback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Move settings such as damage, stun duration and cooldown are defined in
 For example, Party Table Kick's values live at `AbilityConfig.BlackLeg.PartyTableKick`
 and Power Punch uses `AbilityConfig.BasicCombat.PowerPunch`.
 
+### Knockback Types
+
+`ReplicatedStorage.Modules.Combat.KnockbackConfig` defines different
+knockback direction modes. A new mode called `HitboxTravelDirection`
+uses the velocity of the hitbox that triggered the attack. Currently
+only Power Punch is configured to use this mode.
+
 ## Development Setup
 
 This project uses [Rojo](https://github.com/rojo-rbx/rojo) to build place files. The recommended way to install Rojo is with [Aftman](https://github.com/LPGhatguy/aftman).

--- a/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
@@ -64,6 +64,9 @@ function HitboxClient.CastHitbox(
 
     local hitbox = createWeldedHitbox(hrp, offsetCFrame, size, duration, shape)
     if not hitbox then return end
+    if Config.GameSettings.DebugEnabled then
+        print("[HitboxClient] CastHitbox", offsetCFrame, size, duration, travelDistance)
+    end
 
         local originCF = hitbox.CFrame
         local dir = hrp.CFrame.LookVector
@@ -106,11 +109,17 @@ function HitboxClient.CastHitbox(
 
                         if fireOnHit then
                                 if #playerTargets == 0 and fireOnMiss and remoteEvent then
+                                        if Config.GameSettings.DebugEnabled then
+                                                print("[HitboxClient] Miss -> firing remote with dir", extraArgs)
+                                        end
                                         remoteEvent:FireServer({}, table.unpack(extraArgs or {}))
                                 end
                         else
                                 if #playerTargets > 0 or fireOnMiss then
                                         if remoteEvent then
+                                                if Config.GameSettings.DebugEnabled then
+                                                        print("[HitboxClient] Firing remote with targets", playerTargets, extraArgs)
+                                                end
                                                 remoteEvent:FireServer(playerTargets, table.unpack(extraArgs or {}))
                                         else
                                                 local comboIndex = CombatConfig._lastUsedComboIndex or 1

--- a/src/ReplicatedStorage/Modules/Combat/KnockbackConfig.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackConfig.lua
@@ -5,6 +5,7 @@ local KnockbackConfig = {}
 KnockbackConfig.Type = {
     AttackerFacingDirection = "AttackerFacingDirection",
     HitboxVelocityDirection = "HitboxVelocityDirection",
+    HitboxTravelDirection = "HitboxTravelDirection",
     AwayFromAttacker = "AwayFromAttacker",
 }
 
@@ -20,6 +21,11 @@ KnockbackConfig.Params = {
         Duration = 0.4,
         Lift = 3,
     },
+    [KnockbackConfig.Type.HitboxTravelDirection] = {
+        Distance = 25,
+        Duration = 0.4,
+        Lift = 3,
+    },
     [KnockbackConfig.Type.AwayFromAttacker] = {
         Distance = 25,
         Duration = 0.4,
@@ -28,7 +34,8 @@ KnockbackConfig.Params = {
 }
 
 function KnockbackConfig.GetDirection(directionType, attackerRoot, targetRoot, hitboxDir)
-    if directionType == KnockbackConfig.Type.HitboxVelocityDirection then
+    if directionType == KnockbackConfig.Type.HitboxVelocityDirection
+        or directionType == KnockbackConfig.Type.HitboxTravelDirection then
         if typeof(hitboxDir) == "Vector3" and hitboxDir.Magnitude > 0 then
             return hitboxDir.Unit
         end

--- a/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
@@ -14,7 +14,11 @@ KnockbackService.DirectionType = KnockbackConfig.Type
 
 -- Backwards compatible helper
 function KnockbackService.ComputeDirection(directionType, attackerRoot, enemyRoot, hitboxDir)
-    return KnockbackConfig.GetDirection(directionType, attackerRoot, enemyRoot, hitboxDir)
+    local dir = KnockbackConfig.GetDirection(directionType, attackerRoot, enemyRoot, hitboxDir)
+    if DEBUG then
+        print("[KnockbackService] ComputeDirection", directionType, dir, "hitboxDir", hitboxDir)
+    end
+    return dir
 end
 
 -- Utility to check active knockback forces on a root part

--- a/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
@@ -27,7 +27,7 @@ AbilityConfig.BasicCombat = {
         HitboxDuration = 0.5,
         HitboxDistance = 5,
         Cooldown = 4,
-        KnockbackDirection = "AttackerFacingDirection",
+        KnockbackDirection = "HitboxTravelDirection",
     },
 }
 

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -107,11 +107,15 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
             local knockback = CombatConfig.M1
+            local hbDir = typeof(dir) == "Vector3" and dir or nil
+            if DEBUG then
+                print("[PowerPunch] Knockback params", PowerPunchConfig.KnockbackDirection, hbDir)
+            end
             KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
                 DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
                 AttackerRoot = hrp,
                 TargetRoot = enemyRoot,
-                HitboxDirection = typeof(dir) == "Vector3" and dir or nil,
+                HitboxDirection = hbDir,
                 Distance = knockback.KnockbackDistance,
                 Duration = knockback.KnockbackDuration,
                 Lift = knockback.KnockbackLift,


### PR DESCRIPTION
## Summary
- describe new knockback type HitboxTravelDirection and add docs
- use HitboxTravelDirection for Power Punch
- expand knockback debug output
- trace hitbox events when firing remotes

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f0b4f7ec832db3cacb9dfad6a33f