### PR TITLE
Implement custom overhead bars

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -8,6 +8,7 @@ local Players = game:GetService("Players")
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local PlayerStats = require(ReplicatedStorage.Modules.Config.PlayerStats)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
+local OverheadBarService = require(ReplicatedStorage.Modules.UI.OverheadBarService)
 
 -- Remotes
 local remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -64,6 +65,8 @@ function BlockService.StartBlocking(player)
                        BlockHP[player] = PlayerStats.BlockHP
                        BlockingPlayers[player] = true
                        PerfectBlockTimers[player] = tick()
+                       OverheadBarService.SetBlockActive(player, true)
+                       OverheadBarService.UpdateBlock(player, PlayerStats.BlockHP)
                end
        end)
        return true
@@ -87,6 +90,8 @@ function BlockService.StopBlocking(player)
        if VFXEvent then
                VFXEvent:FireAllClients(player, false)
        end
+       OverheadBarService.SetBlockActive(player, false)
+       OverheadBarService.UpdateBlock(player, 0)
 end
 
 -- ⚔️ Handles damage application to a blocking player
@@ -111,14 +116,15 @@ function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker)
 	end
 
 	-- 🩸 Block damage
-	hp -= damage
-	if hp <= 0 then
+        hp -= damage
+        if hp <= 0 then
                 BlockService.StopBlocking(player)
                 return "Broken"
-	else
-		BlockHP[player] = hp
-		return "Damaged"
-	end
+        else
+                BlockHP[player] = hp
+                OverheadBarService.UpdateBlock(player, hp)
+                return "Damaged"
+        end
 end
 
 -- 🧹 Cleanup if player leaves or dies

--- a/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
+++ b/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
@@ -1,0 +1,107 @@
+--ReplicatedStorage.Modules.UI.OverheadBarService
+
+local OverheadBarService = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local PlayerStats = require(ReplicatedStorage.Modules.Config.PlayerStats)
+
+local assets = ReplicatedStorage:WaitForChild("Assets")
+local healthTemplate = assets:WaitForChild("HealthBar")
+local blockTemplate = assets:WaitForChild("BlockBar")
+
+local barInfo = {} --[player] = {healthFrame, healthBase, blockGui, blockFrame, blockBase}
+
+local function updateHealth(player, humanoid)
+    local info = barInfo[player]
+    if not info then return end
+    local ratio = math.clamp(humanoid.Health / humanoid.MaxHealth, 0, 1)
+    local base = info.healthBase
+    info.healthFrame.Size = UDim2.new(
+        base.X.Scale * ratio,
+        base.X.Offset * ratio,
+        base.Y.Scale,
+        base.Y.Offset
+    )
+end
+
+function OverheadBarService.UpdateBlock(player, hp)
+    local info = barInfo[player]
+    if not info then return end
+    local ratio = math.clamp(hp / PlayerStats.BlockHP, 0, 1)
+    local base = info.blockBase
+    info.blockFrame.Size = UDim2.new(
+        base.X.Scale * ratio,
+        base.X.Offset * ratio,
+        base.Y.Scale,
+        base.Y.Offset
+    )
+end
+
+function OverheadBarService.SetBlockActive(player, active)
+    local info = barInfo[player]
+    if info and info.blockGui then
+        info.blockGui.Enabled = active
+    end
+end
+
+local function onCharacterAdded(player, char)
+    local hrp = char:WaitForChild("HumanoidRootPart", 5)
+    local humanoid = char:WaitForChild("Humanoid", 5)
+    if not hrp or not humanoid then return end
+
+    local healthGui = healthTemplate:Clone()
+    healthGui.Name = "HealthBillboard"
+    healthGui.Adornee = hrp
+    pcall(function()
+        healthGui.PlayerToHideFrom = player
+    end)
+    healthGui.Parent = char
+
+    local healthFrame = healthGui:WaitForChild("BarBGMiddle"):WaitForChild("HealthBar")
+    local healthBase = healthFrame.Size
+
+    local blockGui = blockTemplate:Clone()
+    blockGui.Name = "BlockBillboard"
+    blockGui.Adornee = hrp
+    blockGui.Enabled = false
+    blockGui.Parent = char
+
+    local blockFrame = blockGui:WaitForChild("BarBGMiddle"):WaitForChild("BlockBar")
+    local blockBase = blockFrame.Size
+
+    barInfo[player] = {
+        healthFrame = healthFrame,
+        healthBase = healthBase,
+        blockGui = blockGui,
+        blockFrame = blockFrame,
+        blockBase = blockBase,
+    }
+
+    updateHealth(player, humanoid)
+    humanoid.HealthChanged:Connect(function()
+        updateHealth(player, humanoid)
+    end)
+end
+
+Players.PlayerAdded:Connect(function(player)
+    player.CharacterAdded:Connect(function(char)
+        onCharacterAdded(player, char)
+    end)
+    if player.Character then
+        onCharacterAdded(player, player.Character)
+    end
+end)
+
+for _, p in ipairs(Players:GetPlayers()) do
+    if p.Character then
+        onCharacterAdded(p, p.Character)
+    end
+end
+
+Players.PlayerRemoving:Connect(function(player)
+    barInfo[player] = nil
+end)
+
+return OverheadBarService

--- a/src/ReplicatedStorage/Modules/UI/init.meta.json
+++ b/src/ReplicatedStorage/Modules/UI/init.meta.json
@@ -1,0 +1,3 @@
+{
+  "ignoreUnknownInstances": true
+}

--- a/src/StarterPlayer/StarterPlayerScripts/HideDefaultHealth.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/HideDefaultHealth.client.lua
@@ -1,0 +1,3 @@
+-- StarterPlayerScripts > HideDefaultHealth
+local StarterGui = game:GetService("StarterGui")
+StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Health, false)


### PR DESCRIPTION
## Summary
- hide the default Roblox health UI
- create `OverheadBarService` to attach billboard health/block bars to characters
- update `BlockService` to keep block bar state synced

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa9f19f0832d8f5493575444ef6d