### PR TITLE
Fix Power Punch knockback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ and Power Punch uses `AbilityConfig.BasicCombat.PowerPunch`.
 ### Knockback Types
 
 `ReplicatedStorage.Modules.Combat.KnockbackConfig` defines different
-knockback direction modes. A new mode called `HitboxTravelDirection`
-uses the velocity of the hitbox that triggered the attack. Currently
-only Power Punch is configured to use this mode.
+knockback direction modes. A mode called `HitboxTravelDirection`
+uses the velocity of the hitbox that triggered the attack. No moves
+currently use this mode.
 
 ## Development Setup
 

--- a/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/AbilityConfig.lua
@@ -27,7 +27,7 @@ AbilityConfig.BasicCombat = {
         HitboxDuration = 0.5,
         HitboxDistance = 5,
         Cooldown = 4,
-        KnockbackDirection = "HitboxTravelDirection",
+        KnockbackDirection = "AttackerFacingDirection",
     },
 }
 

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -104,29 +104,27 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
 
+        StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, false, player, true)
+
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
             local knockback = CombatConfig.M1
-            local hbDir = typeof(dir) == "Vector3" and dir or nil
             if DEBUG then
-                print("[PowerPunch] Knockback params", PowerPunchConfig.KnockbackDirection, hbDir)
+                print("[PowerPunch] Knockback params", PowerPunchConfig.KnockbackDirection)
             end
             KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
                 DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
                 AttackerRoot = hrp,
                 TargetRoot = enemyRoot,
-                HitboxDirection = hbDir,
                 Distance = knockback.KnockbackDistance,
                 Duration = knockback.KnockbackDuration,
                 Lift = knockback.KnockbackLift,
             })
-        end
 
-        StunService:ApplyStun(enemyHumanoid, PowerPunchConfig.StunDuration, false, player, true)
-
-        local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
-        if knockbackAnim then
-            playAnimation(enemyHumanoid, knockbackAnim)
+            local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
+            if knockbackAnim then
+                playAnimation(enemyHumanoid, knockbackAnim)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary
- switch Power Punch to use the same knockback direction as other attacks
- update README knockback docs
- adjust Power Punch server logic to stun before applying knockback

## Testing
- `./rojo build default.project.json -o game.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_6842fd237c50832db126f84ec25c5816