### PR TITLE
Fix default health bar visibility

### DIFF
--- a/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
+++ b/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
@@ -62,6 +62,11 @@ function onCharacterAdded(player, char)
     local humanoid = char:WaitForChild("Humanoid", 5)
     if not hrp or not humanoid then return end
 
+    -- Hide the default Roblox health bar so only the custom bar is visible
+    pcall(function()
+        humanoid.HealthDisplayType = Enum.HumanoidHealthDisplayType.AlwaysOff
+    end)
+
     local healthGui = healthTemplate:Clone()
     healthGui.Name = "HealthBillboard"
     healthGui.Adornee = hrp


### PR DESCRIPTION
## Summary
- hide the built-in Roblox health bar when attaching overhead bars

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430819b950832db13581ba16e3afe5