### PR TITLE
Fix HitEffect configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ knockback direction modes. A mode called `HitboxTravelDirection`
 uses the velocity of the hitbox that triggered the attack. No moves
 currently use this mode.
 
+## Hit Effect Settings
+
+The hit highlight shown when a character is damaged is configured in
+`ReplicatedStorage/Modules/Config/HitEffectConfig.lua`. These values are loaded
+through the main `Config` module and accessible as `Config.HitEffect`.
+
+
 ## Development Setup
 
 This project uses [Rojo](https://github.com/rojo-rbx/rojo) to build place files. The recommended way to install Rojo is with [Aftman](https://github.com/LPGhatguy/aftman).

--- a/src/ReplicatedStorage/Modules/Config/Config.lua
+++ b/src/ReplicatedStorage/Modules/Config/Config.lua
@@ -2,6 +2,9 @@
 
 local Config = {}
 
+-- Import additional sub-configurations
+local HitEffectConfig = require(script.Parent.HitEffectConfig)
+
 Config.GameSettings = {
 	DefaultSprintSpeed = 20,
 	DefaultWalkSpeed = 10,
@@ -11,5 +14,7 @@ Config.GameSettings = {
         DebugEnabled = true, -- Global debug toggle
         AttackerLockoutDuration = 0, -- Remove extra delay after hits
 }
+
+Config.HitEffect = HitEffectConfig
 
 return Config


### PR DESCRIPTION
## Summary
- expose `HitEffect` config through main `Config` module
- document hit effect settings in the README

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68430d81f078832d99df07a17cdf027e