### PR TITLE
Fix blocking during M1

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -31,6 +31,7 @@ local blockHeld = false
 local retryConn: RBXScriptConnection? = nil
 local activeVFX: Instance? = nil
 local otherVFX = {}
+local blockDisabledUntil = 0
 
 -- Plays the block hold animation. When skipVFX is true the visual effect is not
 -- spawned yet, allowing us to wait for server confirmation before showing it.
@@ -142,6 +143,7 @@ local function attemptBlock()
        if not blockHeld or isBlocking then return end
        if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
        local now = tick()
+       if now < blockDisabledUntil then return end
        if now - lastBlockEnd < blockCooldown then return end
        if not HasValidBlockingTool() then return end
 
@@ -202,7 +204,16 @@ function BlockClient.OnInputEnded(input, gameProcessed)
 end
 
 function BlockClient.IsBlocking()
-	return isBlocking
+        return isBlocking
+end
+
+-- Prevent starting a block for the given duration (in seconds)
+function BlockClient.DisableFor(duration)
+        if typeof(duration) ~= "number" or duration <= 0 then return end
+        local endTime = tick() + duration
+        if endTime > blockDisabledUntil then
+                blockDisabledUntil = endTime
+        end
 end
 
 return BlockClient

--- a/src/ReplicatedStorage/Modules/Combat/M1AnimationClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1AnimationClient.lua
@@ -12,6 +12,8 @@ local currentTrack: AnimationTrack? = nil
 local currentAnimId: string? = nil
 
 -- ✅ Plays a new M1 animation and cancels the previous one
+-- Plays the requested M1 animation and returns its length in seconds if
+-- successfully started.
 function M1AnimationClient.Play(styleKey: string, comboIndex: number)
 	local character = player.Character or player.CharacterAdded:Wait()
 	local humanoid = character:FindFirstChildOfClass("Humanoid")
@@ -49,14 +51,16 @@ function M1AnimationClient.Play(styleKey: string, comboIndex: number)
 	local animation = Instance.new("Animation")
 	animation.AnimationId = animId
 
-	local track = animator:LoadAnimation(animation)
-	track.Priority = Enum.AnimationPriority.Action
-	track:Play()
+        local track = animator:LoadAnimation(animation)
+        track.Priority = Enum.AnimationPriority.Action
+        track:Play()
 
-	currentTrack = track
-	currentAnimId = animId
+        currentTrack = track
+        currentAnimId = animId
 
-	print("[M1AnimationClient] Played animation:", animId)
+        print("[M1AnimationClient] Played animation:", animId)
+
+        return track.Length
 end
 
 return M1AnimationClient

--- a/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
@@ -62,8 +62,11 @@ function M1InputClient.OnInputBegan(input, gameProcessed)
                 local lockDur = CombatConfig.M1.DelayBetweenHits
                 StunStatusClient.LockFor(lockDur)
 
-		-- 🎬 Local animation
-		M1AnimationClient.Play(styleKey, comboIndex)
+                -- 🎬 Local animation
+                local animLength = M1AnimationClient.Play(styleKey, comboIndex)
+                if animLength then
+                        BlockClient.DisableFor(animLength)
+                end
 
 		-- 🧊 Trigger hitbox
                 task.delay(CombatConfig.M1.HitDelay, function()


### PR DESCRIPTION
## Summary
- prevent blocking until the current M1 animation finishes
- expose animation duration from `M1AnimationClient`
- track a block lock timer in `BlockClient`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684316ea4088832d8a0f46f0e5c0e066