### PR TITLE
Fix perfect block not breaking block and add stun anim

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -100,20 +100,20 @@ end
 function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker)
        if not BlockingPlayers[player] then return nil end
 
+       local hp = BlockHP[player] or 0
+       local timeSinceStart = tick() - (PerfectBlockTimers[player] or 0)
+
+       -- 🌀 Perfect block window takes priority even against block breakers
+       if timeSinceStart <= CombatConfig.Blocking.PerfectBlockWindow then
+               -- Reflect to attacker happens in CombatService
+               BlockService.StopBlocking(player)
+               return "Perfect"
+       end
+
        if isBlockBreaker then
                BlockService.StopBlocking(player)
                return "Broken"
        end
-
-	local hp = BlockHP[player] or 0
-	local timeSinceStart = tick() - (PerfectBlockTimers[player] or 0)
-
-	-- 🌀 Perfect block window
-	if timeSinceStart <= CombatConfig.Blocking.PerfectBlockWindow then
-		-- Reflect to attacker happens in CombatService
-                BlockService.StopBlocking(player)
-                return "Perfect"
-	end
 
 	-- 🩸 Block damage
         hp -= damage

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -125,7 +125,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerKick] Perfect block by", enemyPlayer.Name) end
-            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
             BlockEvent:FireClient(enemyPlayer, false)
             continue
         elseif blockResult == "Damaged" then

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -134,7 +134,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerPunch] Perfect block by", enemyPlayer.Name) end
-            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
             BlockEvent:FireClient(enemyPlayer, false)
             continue
         elseif blockResult == "Damaged" then


### PR DESCRIPTION
## Summary
- perfect block should override block-breaking attacks
- use PerfectBlock stun animation when moves are perfect blocked

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843473536b8832d93e1b06758705601