### PR TITLE
Fix perfect block not persisting

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -106,7 +106,8 @@ function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker)
        -- 🌀 Perfect block window takes priority even against block breakers
        if timeSinceStart <= CombatConfig.Blocking.PerfectBlockWindow then
                -- Reflect to attacker happens in CombatService
-               BlockService.StopBlocking(player)
+               -- Do not stop blocking on a perfect block so the player remains
+               -- in a blocking state
                return "Perfect"
        end
 

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -118,7 +118,6 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 if blockResult == "Perfect" then
                         blockHit = true
                         StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
-                        BlockEvent:FireClient(enemyPlayer, false)
                         local soundId = SoundConfig.Blocking.PerfectBlock
                         if soundId then
                                 SoundUtils:PlaySpatialSound(soundId, hrp)

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -144,7 +144,6 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             blockHit = true
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
             playAnimation(humanoid, AnimationData.Stun.PerfectBlock)
-            BlockEvent:FireClient(enemyPlayer, false)
             local soundId = SoundConfig.Blocking.PerfectBlock
             if soundId then
                 SoundUtils:PlaySpatialSound(soundId, hrp)

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -126,7 +126,6 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerKick] Perfect block by", enemyPlayer.Name) end
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
-            BlockEvent:FireClient(enemyPlayer, false)
             continue
         elseif blockResult == "Damaged" then
             if DEBUG then print("[PowerKick] Block damaged", enemyPlayer.Name) end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -135,7 +135,6 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerPunch] Perfect block by", enemyPlayer.Name) end
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
-            BlockEvent:FireClient(enemyPlayer, false)
             continue
         elseif blockResult == "Damaged" then
             if DEBUG then print("[PowerPunch] Block damaged", enemyPlayer.Name) end


### PR DESCRIPTION
## Summary
- keep blocking state after a perfect block
- stop forcing the client to end blocking on perfect block

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434adff29c832d95ef6ac54ce2f46b