### PR TITLE
Fix perfect block effects on special moves

### DIFF
--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -142,6 +142,14 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
         if blockResult == "Perfect" then
             if DEBUG then print("[PartyTableKick] Perfect block by", enemyPlayer.Name) end
             blockHit = true
+            stopAnimation(humanoid)
+            local soundInst = activeLoopSounds[player]
+            if soundInst then
+                soundInst:Destroy()
+                activeLoopSounds[player] = nil
+            end
+            activeDrain[player] = nil
+            StaminaService.ResumeRegen(player)
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
             playAnimation(humanoid, AnimationData.Stun.PerfectBlock)
             local soundId = SoundConfig.Blocking.PerfectBlock

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -52,6 +52,14 @@ local function playAnimation(humanoid, animId)
     end)
 end
 
+local function stopAnimation(humanoid)
+    local current = activeTracks[humanoid]
+    if current and current.IsPlaying then
+        current:Stop(0.05)
+    end
+    activeTracks[humanoid] = nil
+end
+
 StartEvent.OnServerEvent:Connect(function(player)
     if DEBUG then print("[PowerKick] StartEvent from", player.Name) end
     local char = player.Character
@@ -125,7 +133,12 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerKick] Perfect block by", enemyPlayer.Name) end
+            stopAnimation(humanoid)
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
+            local soundId = SoundConfig.Blocking.PerfectBlock
+            if soundId then
+                SoundUtils:PlaySpatialSound(soundId, hrp)
+            end
             continue
         elseif blockResult == "Damaged" then
             if DEBUG then print("[PowerKick] Block damaged", enemyPlayer.Name) end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -60,6 +60,14 @@ local function playAnimation(humanoid, animId)
     end)
 end
 
+local function stopAnimation(humanoid)
+    local current = activeTracks[humanoid]
+    if current and current.IsPlaying then
+        current:Stop(0.05)
+    end
+    activeTracks[humanoid] = nil
+end
+
 StartEvent.OnServerEvent:Connect(function(player)
     if DEBUG then print("[PowerPunch] StartEvent from", player.Name) end
     local char = player.Character
@@ -134,7 +142,12 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerPunch] Perfect block by", enemyPlayer.Name) end
+            stopAnimation(humanoid)
             StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
+            local soundId = SoundConfig.Blocking.PerfectBlock
+            if soundId then
+                SoundUtils:PlaySpatialSound(soundId, hrp)
+            end
             continue
         elseif blockResult == "Damaged" then
             if DEBUG then print("[PowerPunch] Block damaged", enemyPlayer.Name) end


### PR DESCRIPTION
## Summary
- stop active move tracks when perfect-blocked
- play the perfect block sound on PowerKick and PowerPunch
- clean up PartyTableKick state when perfect-blocked

## Testing
- `./rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68434ea83ac8832d9dd629ef0bff6a55