### PR TITLE
Fix perfect block stun attacker lock

### DIFF
--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -117,7 +117,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, damage, false)
                 if blockResult == "Perfect" then
                         blockHit = true
-                        StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
+                        StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, player)
                         local soundId = SoundConfig.Blocking.PerfectBlock
                         if soundId then
                                 SoundUtils:PlaySpatialSound(soundId, hrp)

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -150,7 +150,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             end
             activeDrain[player] = nil
             StaminaService.ResumeRegen(player)
-            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, enemyPlayer)
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), false, player)
             playAnimation(humanoid, AnimationData.Stun.PerfectBlock)
             local soundId = SoundConfig.Blocking.PerfectBlock
             if soundId then

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -134,7 +134,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerKick] Perfect block by", enemyPlayer.Name) end
             stopAnimation(humanoid)
-            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, player)
             local soundId = SoundConfig.Blocking.PerfectBlock
             if soundId then
                 SoundUtils:PlaySpatialSound(soundId, hrp)

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -143,7 +143,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerPunch] Perfect block by", enemyPlayer.Name) end
             stopAnimation(humanoid)
-            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, enemyPlayer)
+            StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, player)
             local soundId = SoundConfig.Blocking.PerfectBlock
             if soundId then
                 SoundUtils:PlaySpatialSound(soundId, hrp)


### PR DESCRIPTION
## Summary
- ensure the attacker is locked when their move is perfect blocked

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843524dc218832d937bd22373dd6c8c