### PR TITLE
Remove spaces from tool names

### DIFF
--- a/src/ReplicatedStorage/Modules/Config/ToolConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/ToolConfig.lua
@@ -3,8 +3,8 @@
 local ToolConfig = {}
 
 ToolConfig.ValidCombatTools = {
-	["Basic Combat"] = true,
-	["Black Leg"] = true,
+        ["BasicCombat"] = true,
+        ["BlackLeg"] = true,
 	-- Add more tools here
 }
 

--- a/src/ReplicatedStorage/Modules/MenuCfgs/ButtonCfg.lua
+++ b/src/ReplicatedStorage/Modules/MenuCfgs/ButtonCfg.lua
@@ -8,8 +8,8 @@ local ButtonCfg = {
 		{ Name = "4 - Settings",  Image = "rbxassetid://YOUSETTINGS_IMG", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,255,200) }
 	},
 	Selection = {
-		{ Name = "1 - Basic Combat", Image = "rbxassetid://128114491023651", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,255,255) },
-		{ Name = "2 - Black Leg",    Image = "rbxassetid://135812261993733", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(255,200,255) },
+                { Name = "1 - BasicCombat", Image = "rbxassetid://128114491023651", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,255,255) },
+                { Name = "2 - BlackLeg",    Image = "rbxassetid://135812261993733", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(255,200,255) },
 		-- Add more as needed!
 	},
 	Shop = {

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -99,7 +99,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
 	if not humanoid or not hrp then return end
 
         local tool = char:FindFirstChildOfClass("Tool")
-        local styleKey = (tool and tool.Name or "Basic Combat"):gsub(" ", "")
+        local styleKey = (tool and tool.Name or "BasicCombat"):gsub(" ", "")
         local damage = ToolConfig.ToolStats[styleKey] and ToolConfig.ToolStats[styleKey].M1Damage or CombatConfig.M1.DefaultM1Damage
 
         local hitLanded = false

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -81,7 +81,7 @@ StartEvent.OnServerEvent:Connect(function(player)
         return
     end
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Black Leg" then
+    if not tool or tool.Name ~= "BlackLeg" then
         if DEBUG then print("[PartyTableKick] Invalid tool") end
         return
     end
@@ -117,7 +117,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
     end
 
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Black Leg" then
+    if not tool or tool.Name ~= "BlackLeg" then
         if DEBUG then print("[PartyTableKick] Invalid tool during hit") end
         return
     end

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -73,7 +73,7 @@ StartEvent.OnServerEvent:Connect(function(player)
         return
     end
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Black Leg" then
+    if not tool or tool.Name ~= "BlackLeg" then
         if DEBUG then print("[PowerKick] Invalid tool") end
         return
     end
@@ -101,7 +101,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     end
 
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Black Leg" then
+    if not tool or tool.Name ~= "BlackLeg" then
         if DEBUG then print("[PowerKick] Invalid tool during hit") end
         return
     end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -81,7 +81,7 @@ StartEvent.OnServerEvent:Connect(function(player)
         return
     end
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Basic Combat" then
+    if not tool or tool.Name ~= "BasicCombat" then
         if DEBUG then print("[PowerPunch] Invalid tool") end
         return
     end
@@ -110,7 +110,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     end
 
     local tool = char:FindFirstChildOfClass("Tool")
-    if not tool or tool.Name ~= "Basic Combat" then
+    if not tool or tool.Name ~= "BasicCombat" then
         if DEBUG then print("[PowerPunch] Invalid tool during hit") end
         return
     end


### PR DESCRIPTION
## Summary
- update hotbar detection for `BasicCombat` and `BlackLeg`
- update menu config display names
- adjust tool configuration and combat scripts

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68437e0b9144832db68568d9ae27208d