### PR TITLE
Add Rokushiki tool

### DIFF
--- a/src/ReplicatedStorage/Modules/Animations/Combat.lua
+++ b/src/ReplicatedStorage/Modules/Animations/Combat.lua
@@ -13,16 +13,27 @@ Animation.M1 = {
 		Knockback = "rbxassetid://130846337993501"
 	},
 
-	BlackLeg = {
-		Combo = {
-			[1] = "rbxassetid://89499329718727",
-			[2] = "rbxassetid://126344683553001",
-			[3] = "rbxassetid://89499329718727",
-			[4] = "rbxassetid://126344683553001",
-			[5] = "rbxassetid://84882475157331",
-		},
-		Knockback = "rbxassetid://130846337993501"
-	}
+        BlackLeg = {
+                Combo = {
+                        [1] = "rbxassetid://89499329718727",
+                        [2] = "rbxassetid://126344683553001",
+                        [3] = "rbxassetid://89499329718727",
+                        [4] = "rbxassetid://126344683553001",
+                        [5] = "rbxassetid://84882475157331",
+                },
+                Knockback = "rbxassetid://130846337993501"
+        },
+
+        Rokushiki = {
+                Combo = {
+                        [1] = "rbxassetid://114200559376775",
+                        [2] = "rbxassetid://96320001137526",
+                        [3] = "rbxassetid://114200559376775",
+                        [4] = "rbxassetid://96320001137526",
+                        [5] = "rbxassetid://70382508234278",
+                },
+                Knockback = "rbxassetid://130846337993501"
+        }
 }
 
 Animation.Stun = {

--- a/src/ReplicatedStorage/Modules/Animations/Tool.lua
+++ b/src/ReplicatedStorage/Modules/Animations/Tool.lua
@@ -6,7 +6,11 @@ Animation.BasicCombat = {
 }
 
 Animation.BlackLeg = {
-	EquipStance = "rbxassetid://74913824144457"
+        EquipStance = "rbxassetid://74913824144457"
+}
+
+Animation.Rokushiki = {
+        EquipStance = "rbxassetid://107380810816009"
 }
 
 return Animation

--- a/src/ReplicatedStorage/Modules/Config/SoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/SoundConfig.lua
@@ -8,11 +8,16 @@ local SoundConfig = {
 			Miss = "rbxassetid://135883654541622",
 		},
 
-		BlackLeg = {
-			Hit = "rbxassetid://122809552011508",
-			Miss = "rbxassetid://135883654541622",
-		},
-	},
+                BlackLeg = {
+                        Hit = "rbxassetid://122809552011508",
+                        Miss = "rbxassetid://135883654541622",
+                },
+
+                Rokushiki = {
+                        Hit = "rbxassetid://9117969717",
+                        Miss = "rbxassetid://135883654541622",
+                },
+        },
 
 	Blocking = {
 		-- 🛡️ Shared blocking sounds

--- a/src/ReplicatedStorage/Modules/Config/ToolConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/ToolConfig.lua
@@ -5,12 +5,14 @@ local ToolConfig = {}
 ToolConfig.ValidCombatTools = {
         ["BasicCombat"] = true,
         ["BlackLeg"] = true,
-	-- Add more tools here
+        ["Rokushiki"] = true,
+        -- Add more tools here
 }
 
 ToolConfig.ToolStats = {
         BasicCombat = { M1Damage = 35, AllowsBlocking = true },
         BlackLeg = { M1Damage = 35, AllowsBlocking = true },
+        Rokushiki = { M1Damage = 35, AllowsBlocking = true },
         -- Add more tools here
 }
 

--- a/src/ReplicatedStorage/Modules/MenuCfgs/ButtonCfg.lua
+++ b/src/ReplicatedStorage/Modules/MenuCfgs/ButtonCfg.lua
@@ -7,11 +7,12 @@ local ButtonCfg = {
 		{ Name = "3 - Shop",      Image = "rbxassetid://79085581388954",  ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(255,200,200) },
 		{ Name = "4 - Settings",  Image = "rbxassetid://YOUSETTINGS_IMG", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,255,200) }
 	},
-	Selection = {
+        Selection = {
                 { Name = "1 - BasicCombat", Image = "rbxassetid://128114491023651", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,255,255) },
                 { Name = "2 - BlackLeg",    Image = "rbxassetid://135812261993733", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(255,200,255) },
-		-- Add more as needed!
-	},
+                { Name = "3 - Rokushiki",   Image = "rbxassetid://128114491023651", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(255,255,200) },
+                -- Add more as needed!
+        },
 	Shop = {
 		{ Name = "1 - Swords",         Image = "rbxassetid://00000000000001", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(240,240,200) },
 		{ Name = "2 - Fighting Styles",Image = "rbxassetid://00000000000002", ImageColor = Color3.fromRGB(255,255,255), HoverColor = Color3.fromRGB(200,240,240) },

--- a/src/StarterPlayer/StarterPlayerScripts/CustomHotbar.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CustomHotbar.client.lua
@@ -29,6 +29,7 @@ hotbar.Parent = PlayerGui
 
 local basicButton = hotbar:WaitForChild("BasicCombat")
 local blackButton = hotbar:WaitForChild("BlackLeg")
+local rokuButton = hotbar:FindFirstChild("Rokushiki")
 
 -- Display only the button for the player's current tool
 local function updateVisibleButton()
@@ -39,9 +40,14 @@ local function updateVisibleButton()
         or (character and character:FindFirstChild("BasicCombat"))
     local hasBlack = (backpack and backpack:FindFirstChild("BlackLeg"))
         or (character and character:FindFirstChild("BlackLeg"))
+    local hasRoku = rokuButton and ((backpack and backpack:FindFirstChild("Rokushiki"))
+        or (character and character:FindFirstChild("Rokushiki")))
 
     basicButton.Visible = not not hasBasic
     blackButton.Visible = not not hasBlack
+    if rokuButton then
+        rokuButton.Visible = not not hasRoku
+    end
 end
 
 updateVisibleButton()
@@ -111,6 +117,12 @@ hotbar:WaitForChild("BlackLeg").MouseButton1Click:Connect(function()
     toggleTool("BlackLeg")
 end)
 
+if rokuButton then
+    rokuButton.MouseButton1Click:Connect(function()
+        toggleTool("Rokushiki")
+    end)
+end
+
 -- Pressing 1 equips the first available tool, mirroring the default behaviour
 UserInputService.InputBegan:Connect(function(input, gp)
     if gp then return end
@@ -119,6 +131,9 @@ UserInputService.InputBegan:Connect(function(input, gp)
         local preferred = "BasicCombat"
         if not backpack:FindFirstChild(preferred) and not (player.Character and player.Character:FindFirstChild(preferred)) then
             preferred = "BlackLeg"
+            if not backpack:FindFirstChild(preferred) and not (player.Character and player.Character:FindFirstChild(preferred)) then
+                preferred = "Rokushiki"
+            end
         end
         toggleTool(preferred)
     end


### PR DESCRIPTION
## Summary
- add Rokushiki animations
- enable Rokushiki in tool config and sounds
- show Rokushiki selection button
- handle Rokushiki in hotbar UI

## Testing
- `apt-get update`
- `aftman install` *(fails: invalid peer certificate)*
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438d18c6e0832dba7ffa19173c4aa0