### PR TITLE
Fix GetCollisionGroups deprecation

### DIFF
--- a/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
+++ b/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
@@ -4,9 +4,8 @@ local Workspace = game:GetService("Workspace")
 
 local COLLISION_GROUP = "Players"
 
--- ✅ Register the collision group if not present
 local groupExists = false
-for _, group in ipairs(PhysicsService:GetCollisionGroups()) do
+for _, group in ipairs(PhysicsService:GetRegisteredCollisionGroups()) do
         if group.name == COLLISION_GROUP then
                 groupExists = true
                 break


### PR DESCRIPTION
## Summary
- update player collision disabler to use `GetRegisteredCollisionGroups`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684399f99d94832db87f17877eef83e2