### PR TITLE
Remove tool name cleanup

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/ToolController.lua
+++ b/src/ReplicatedStorage/Modules/Combat/ToolController.lua
@@ -50,7 +50,7 @@ function ToolController.SetEquippedTool(tool)
 
 	-- Equip new tool
 	if tool then
-		local styleKey = tool.Name:gsub(" ", "")
+            local styleKey = tool.Name
 		local styleConfig = ToolAnimations[styleKey]
 
 		equippedTool = tool

--- a/src/ServerScriptService/Combat/BlockServer.server.lua
+++ b/src/ServerScriptService/Combat/BlockServer.server.lua
@@ -21,7 +21,7 @@ local function hasValidTool(player)
                return false
        end
 
-       local styleKey = tool.Name:gsub(" ", "")
+       local styleKey = tool.Name
        local stats = ToolConfig.ToolStats[styleKey]
        if stats and stats.AllowsBlocking == false then
                return false

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -99,7 +99,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
 	if not humanoid or not hrp then return end
 
         local tool = char:FindFirstChildOfClass("Tool")
-        local styleKey = (tool and tool.Name or "BasicCombat"):gsub(" ", "")
+       local styleKey = tool and tool.Name or "BasicCombat"
         local damage = ToolConfig.ToolStats[styleKey] and ToolConfig.ToolStats[styleKey].M1Damage or CombatConfig.M1.DefaultM1Damage
 
         local hitLanded = false

--- a/src/ServerScriptService/Movement/DashServer.server.lua
+++ b/src/ServerScriptService/Movement/DashServer.server.lua
@@ -43,7 +43,7 @@ DashEvent.OnServerEvent:Connect(function(player, direction, dashVector)
                return
        end
 
-       local equippedStyle = tool.Name:gsub(" ", "")
+       local equippedStyle = tool.Name
 
        -- Always forward dashVector to the DashModule (module handles all logic now)
        DashModule.ExecuteDash(player, direction, dashVector, equippedStyle)

--- a/src/ServerScriptService/Spawner/RealSpawner.server.lua
+++ b/src/ServerScriptService/Spawner/RealSpawner.server.lua
@@ -13,10 +13,6 @@ local SpawnRequestEvent = SystemRemotes:WaitForChild("SpawnRequestEvent")
 local TOOLS_FOLDER = ReplicatedStorage:WaitForChild("Tools")
 local hasSpawned = require(script.Parent:WaitForChild("SpawnRegistry"))
 
-local function stripPrefix(name)
-	-- Removes "1 - " or "2 - " etc. from button name
-	return name:match("^%d+%s*%-[%s]*(.+)$") or name
-end
 
 local function getRandomSpawnPoint()
 	local map = Workspace:FindFirstChild("Map")
@@ -50,13 +46,9 @@ end
 local function spawnPlayerWithTool(player, toolName)
 	print("[RealSpawner] Spawn request from:", player.Name, "Tool:", toolName)
 
-	-- Remove prefix if present
-	local cleanedToolName = stripPrefix(toolName)
-	print("[RealSpawner] Cleaned tool name:", cleanedToolName)
-
-	local tool = TOOLS_FOLDER:FindFirstChild(cleanedToolName)
-	if not tool then
-		warn("[RealSpawner] Tool not found:", cleanedToolName)
+       local tool = TOOLS_FOLDER:FindFirstChild(toolName)
+       if not tool then
+               warn("[RealSpawner] Tool not found:", toolName)
 		return
 	end
 


### PR DESCRIPTION
## Summary
- stop stripping spaces from tool names
- remove unnecessary prefix stripping in RealSpawner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843a443be78832dbc6259cefb3d9d33