### PR TITLE
Fix damage on block break

### DIFF
--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -138,7 +138,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                         if soundId then
                                 SoundUtils:PlaySpatialSound(soundId, hrp)
                         end
-                        continue
+                        -- fallthrough to apply damage on block break
                 end
 
 		-- ✅ Deal damage and apply stun

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -174,7 +174,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             if soundId then
                 SoundUtils:PlaySpatialSound(soundId, hrp)
             end
-            continue
+            -- fallthrough to apply damage on block break
         end
 
         enemyHumanoid:TakeDamage(cfg.DamagePerHit)

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -160,7 +160,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
                 -- reserved for potential future effects
             end
 
-            continue
+            -- fallthrough to apply damage on block break
         end
 
         enemyHumanoid:TakeDamage(PowerKickConfig.Damage)

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -188,7 +188,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
                 end
             end
 
-            continue
+            -- fallthrough to apply damage on block break
         end
 
         enemyHumanoid:TakeDamage(PowerPunchConfig.Damage)


### PR DESCRIPTION
## Summary
- ensure block break still deals damage for combat tools

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684455d82240832d81d1c4a235a5f464