### PR TITLE
Fix move inputs when typing in chat

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -92,6 +92,9 @@ end
 -- 🕹️ Route all input through controllers
 UserInputService.InputBegan:Connect(function(input, gameProcessed)
         local typing = typingInChat or UserInputService:GetFocusedTextBox() ~= nil
+        if typing then
+                return
+        end
         gameProcessed = gameProcessed or typing
         if DEBUG and input.UserInputType == Enum.UserInputType.Keyboard then
                 print("[InputController] InputBegan:", input.KeyCode.Name, "GP:", gameProcessed)
@@ -109,6 +112,9 @@ end)
 
 UserInputService.InputEnded:Connect(function(input, gameProcessed)
         local typing = typingInChat or UserInputService:GetFocusedTextBox() ~= nil
+        if typing then
+                return
+        end
         gameProcessed = gameProcessed or typing
         if DEBUG and input.UserInputType == Enum.UserInputType.Keyboard then
                 print("[InputController] InputEnded:", input.KeyCode.Name, "GP:", gameProcessed)


### PR DESCRIPTION
## Summary
- stop routing input events while chat is focused

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68445703d078832d9ead546e3b37e8f6