### PR TITLE
Allow dashing without tools

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -113,13 +113,22 @@ function DashClient.OnInputBegan(input, gameProcessed)
 
     if tick() - lastDashTime < DashConfig.Cooldown then return end
     if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() or BlockClient.IsBlocking() then return end
-    if not ToolController.IsValidCombatTool() then return end
+    -- Basic dashing should be available even when no tool is equipped. We only
+    -- restrict dashing if a tool is equipped and specifically disallowed by the
+    -- game (none at the moment). The style key will determine if any special
+    -- dash settings apply.
     if StaminaService.GetStamina(player) < 10 then return end
 
         local direction, dashVector = getDashInputAndVector()
         if not direction or not dashVector then return end
 
+        -- Only the Rokushiki tool changes the dash behaviour. Any other tool
+        -- (or no tool) should result in a normal dash, so we ignore the style
+        -- key unless it is explicitly Rokushiki.
         local styleKey = ToolController.GetEquippedStyleKey()
+        if styleKey ~= "Rokushiki" then
+                styleKey = nil
+        end
 
         lastDashTime = tick()
         playDashAnimation(direction)

--- a/src/ServerScriptService/Movement/DashServer.server.lua
+++ b/src/ServerScriptService/Movement/DashServer.server.lua
@@ -10,7 +10,6 @@ local DashModule = require(ReplicatedStorage.Modules.Movement.DashModule)
 local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
-local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
 
 local validDirections = {
 	Forward = true,
@@ -39,11 +38,14 @@ DashEvent.OnServerEvent:Connect(function(player, direction, dashVector)
 
        local char = player.Character
        local tool = char and char:FindFirstChildOfClass("Tool")
-       if not tool or not ToolConfig.ValidCombatTools[tool.Name] then
-               return
-       end
 
-       local equippedStyle = tool.Name
+       -- Allow dashing even when no tool is equipped. Only the Rokushiki tool
+       -- modifies dash behaviour, so styleKey is nil unless that tool is
+       -- equipped.
+       local equippedStyle = nil
+       if tool and tool.Name == "Rokushiki" then
+               equippedStyle = "Rokushiki"
+       end
 
        -- Always forward dashVector to the DashModule (module handles all logic now)
        DashModule.ExecuteDash(player, direction, dashVector, equippedStyle)


### PR DESCRIPTION
## Summary
- let clients dash even when no combat tool is equipped
- only Rokushiki tool modifies dash style
- allow server dash requests when unarmed

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68445fca0100832d84703b8f3b5c6575