### PR TITLE
Add damage text feature

### DIFF
--- a/src/ReplicatedStorage/Modules/Effects/DamageText.lua
+++ b/src/ReplicatedStorage/Modules/Effects/DamageText.lua
@@ -1,0 +1,59 @@
+--ReplicatedStorage.Modules.Effects.DamageText
+
+local DamageText = {}
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Debris = game:GetService("Debris")
+
+local template
+local function getTemplate()
+    if template then return template end
+    local assets = ReplicatedStorage:FindFirstChild("Assets")
+    if assets then
+        template = assets:FindFirstChild("DamageText")
+    end
+    return template
+end
+
+function DamageText.Show(target: Instance, amount: number)
+    if typeof(amount) ~= "number" or not target then return end
+
+    local char = target
+    if target:IsA("Humanoid") then
+        char = target.Parent
+    end
+
+    local root = char and char:FindFirstChild("HumanoidRootPart")
+    if not root then return end
+
+    local gui
+    local tmpl = getTemplate()
+    if tmpl then
+        gui = tmpl:Clone()
+    else
+        gui = Instance.new("BillboardGui")
+        gui.Size = UDim2.fromScale(2, 1)
+        gui.AlwaysOnTop = true
+        local label = Instance.new("TextLabel")
+        label.Name = "TextLabel"
+        label.BackgroundTransparency = 1
+        label.Size = UDim2.fromScale(1, 1)
+        label.TextColor3 = Color3.new(1, 0, 0)
+        label.TextStrokeTransparency = 0
+        label.Font = Enum.Font.SourceSansBold
+        label.TextScaled = true
+        label.Parent = gui
+    end
+
+    gui.Name = "DamageText"
+    gui.Adornee = root
+    local label = gui:FindFirstChildOfClass("TextLabel")
+    if label then
+        label.Text = tostring(math.floor(amount))
+    end
+    gui.Parent = char
+
+    Debris:AddItem(gui, 1)
+end
+
+return DamageText

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -13,6 +13,7 @@ print("[CombatService] Loaded")
 local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
+local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local KnockbackService = require(ReplicatedStorage.Modules.Combat.KnockbackService)
 
@@ -142,8 +143,9 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 end
 
 		-- ✅ Deal damage and apply stun
-		enemyHumanoid:TakeDamage(damage)
-		hitLanded = true
+                enemyHumanoid:TakeDamage(damage)
+                DamageText.Show(enemyHumanoid, damage)
+                hitLanded = true
 
                 local stunDuration = isFinal and CombatConfig.M1.M1_5StunDuration or CombatConfig.M1.M1StunDuration
                 StunService:ApplyStun(enemyHumanoid, stunDuration, isFinal, player, isFinal)

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -16,6 +16,7 @@ local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
+local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
@@ -178,6 +179,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
         end
 
         enemyHumanoid:TakeDamage(cfg.DamagePerHit)
+        DamageText.Show(enemyHumanoid, cfg.DamagePerHit)
         hitLanded = true
         if DEBUG then print("[PartyTableKick] Hit", enemyPlayer.Name) end
         local stunDur = isFinal and CombatConfig.M1.M1_5StunDuration or cfg.StunDuration

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -12,6 +12,7 @@ local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
+local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
@@ -164,6 +165,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
 
         enemyHumanoid:TakeDamage(PowerKickConfig.Damage)
+        DamageText.Show(enemyHumanoid, PowerKickConfig.Damage)
         if DEBUG then print("[PowerKick] Hit", enemyPlayer.Name, "for", PowerKickConfig.Damage) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -13,6 +13,7 @@ local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
+local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
@@ -192,6 +193,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
 
         enemyHumanoid:TakeDamage(PowerPunchConfig.Damage)
+        DamageText.Show(enemyHumanoid, PowerPunchConfig.Damage)
         if DEBUG then print("[PowerPunch] Hit", enemyPlayer.Name, "for", PowerPunchConfig.Damage) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)


### PR DESCRIPTION
## Summary
- show floating damage numbers
- hook up damage text to M1s and special moves

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844649f9f30832db6de1e14b2785f17