### PR TITLE
Fix Rokushiki teleport while moving

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
@@ -50,6 +50,13 @@ function Teleport.OnInputBegan(input, gp)
         pos = hrp.Position + delta
     end
 
+    -- Move the character locally first so the server update isn't overwritten
+    -- by client-side physics when the player is in motion. The server will
+    -- validate the request and replicate the same position back to all clients.
+    hrp.CFrame = CFrame.new(pos)
+    local vel = hrp.AssemblyLinearVelocity
+    hrp.AssemblyLinearVelocity = Vector3.new(0, vel.Y, 0)
+
     TeleportEvent:FireServer(pos)
 
     local sfx = TeleportConfig.Sound and TeleportConfig.Sound.Use


### PR DESCRIPTION
## Summary
- ensure Rokushiki teleport works while moving by applying position change locally first

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448e303fb4832db670fab577a5632f