### PR TITLE
Add Tekkai defensive move

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -9,6 +9,7 @@ local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local PlayerStats = require(ReplicatedStorage.Modules.Config.PlayerStats)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 local OverheadBarService = require(ReplicatedStorage.Modules.UI.OverheadBarService)
+local TekkaiService = require(ReplicatedStorage.Modules.Combat.TekkaiService)
 
 -- Remotes
 local remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -98,6 +99,10 @@ end
 -- Returns: "Perfect", "Damaged", "Broken", or nil (not blocking)
 -- @param isBlockBreaker boolean? whether the attack ignores blocking
 function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker)
+       if TekkaiService.IsActive(player) then
+               return TekkaiService.ApplyDamage(player, damage)
+       end
+
        if not BlockingPlayers[player] then return nil end
 
        local hp = BlockHP[player] or 0
@@ -132,6 +137,9 @@ end
 local function cleanup(player)
         BlockService.StopBlocking(player)
         BlockCooldowns[player] = nil
+        if TekkaiService.IsActive(player) then
+                TekkaiService.Stop(player)
+        end
 end
 
 Players.PlayerRemoving:Connect(cleanup)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
@@ -1,0 +1,92 @@
+--ReplicatedStorage.Modules.Combat.Moves.TekkaiClient
+local Tekkai = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+
+local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
+local TekkaiEvent = CombatRemotes:WaitForChild("TekkaiEvent")
+
+local Animations = require(ReplicatedStorage.Modules.Animations.Combat)
+local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
+local TekkaiConfig = AbilityConfig.Rokushiki.Tekkai or {}
+local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
+local BlockClient = require(ReplicatedStorage.Modules.Combat.BlockClient)
+local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
+local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
+local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+
+local KEY = Enum.KeyCode.E
+local active = false
+local track
+local prevWalk
+local prevJump
+
+local function getCharacter()
+    local player = Players.LocalPlayer
+    local char = player.Character
+    if not char then return nil end
+    local humanoid = char:FindFirstChildOfClass("Humanoid")
+    local animator = humanoid and humanoid:FindFirstChildOfClass("Animator")
+    return char, humanoid, animator
+end
+
+local function playAnimation(animator, animId)
+    if not animator or not animId then return nil end
+    local anim = Instance.new("Animation")
+    anim.AnimationId = animId
+    local t = animator:LoadAnimation(anim)
+    t.Priority = Enum.AnimationPriority.Action
+    t.Looped = true
+    t:Play()
+    return t
+end
+
+TekkaiEvent.OnClientEvent:Connect(function(tekkaiPlayer, state)
+    if tekkaiPlayer ~= Players.LocalPlayer then return end
+    local char, humanoid, animator = getCharacter()
+    if not humanoid then return end
+    if state then
+        active = true
+        prevWalk = humanoid.WalkSpeed
+        prevJump = humanoid.JumpPower
+        humanoid.WalkSpeed = 0
+        humanoid.JumpPower = 0
+        track = playAnimation(animator, Animations.Blocking.BlockHold)
+    else
+        active = false
+        if track then
+            track:Stop()
+            track:Destroy()
+            track = nil
+        end
+        humanoid.WalkSpeed = prevWalk or humanoid.WalkSpeed
+        humanoid.JumpPower = prevJump or humanoid.JumpPower
+        prevWalk = nil
+        prevJump = nil
+    end
+end)
+
+function Tekkai.OnInputBegan(input, gp)
+    if gp then return end
+    if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
+    if active then return end
+    if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
+    if BlockClient.IsBlocking() then return end
+    local style = ToolController.GetEquippedStyleKey()
+    if style ~= "Rokushiki" then return end
+    if not ToolController.IsValidCombatTool() then return end
+    if StaminaService.GetStamina(Players.LocalPlayer) <= 0 then return end
+
+    MovementClient.StopSprint()
+    TekkaiEvent:FireServer(true)
+end
+
+function Tekkai.OnInputEnded(input, gp)
+    if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
+    if not active then return end
+    TekkaiEvent:FireServer(false)
+end
+
+return Tekkai

--- a/src/ReplicatedStorage/Modules/Combat/TekkaiService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/TekkaiService.lua
@@ -1,0 +1,106 @@
+--ReplicatedStorage.Modules.Combat.TekkaiService
+
+local TekkaiService = {}
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
+local TekkaiConfig = AbilityConfig.Rokushiki.Tekkai or {}
+local OverheadBarService = require(ReplicatedStorage.Modules.UI.OverheadBarService)
+local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+
+local remotes = ReplicatedStorage:WaitForChild("Remotes")
+local combatFolder = remotes:WaitForChild("Combat")
+local TekkaiEvent = combatFolder:WaitForChild("TekkaiEvent")
+
+local ACTIVE = {}
+local HP = {}
+local PREV_MOVEMENT = {}
+
+function TekkaiService.IsActive(player)
+    return ACTIVE[player] == true
+end
+
+function TekkaiService.GetHP(player)
+    return HP[player] or (TekkaiConfig.BlockHP or 750)
+end
+
+function TekkaiService.GetDrainRate()
+    return TekkaiConfig.StaminaDrain or 10
+end
+
+local function cleanup(player)
+    ACTIVE[player] = nil
+    HP[player] = nil
+    PREV_MOVEMENT[player] = nil
+end
+
+function TekkaiService.Start(player)
+    if ACTIVE[player] then return false end
+    local char = player.Character
+    local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+    if not humanoid then return false end
+
+    ACTIVE[player] = true
+    HP[player] = TekkaiConfig.BlockHP or 750
+
+    OverheadBarService.SetTekkaiActive(player, true)
+    OverheadBarService.UpdateTekkai(player, HP[player], TekkaiConfig.BlockHP or 750)
+    StaminaService.PauseRegen(player)
+
+    PREV_MOVEMENT[player] = {Walk = humanoid.WalkSpeed, Jump = humanoid.JumpPower}
+    humanoid.WalkSpeed = 0
+    humanoid.JumpPower = 0
+
+    return true
+end
+
+function TekkaiService.Stop(player)
+    if not ACTIVE[player] then return end
+    local char = player.Character
+    local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+
+    local prev = PREV_MOVEMENT[player]
+    if humanoid and prev then
+        humanoid.WalkSpeed = prev.Walk or humanoid.WalkSpeed
+        humanoid.JumpPower = prev.Jump or humanoid.JumpPower
+    end
+
+    OverheadBarService.SetTekkaiActive(player, false)
+    OverheadBarService.UpdateTekkai(player, 0, TekkaiConfig.BlockHP or 750)
+    StaminaService.ResumeRegen(player)
+    cleanup(player)
+
+    TekkaiEvent:FireAllClients(player, false)
+end
+
+function TekkaiService.ApplyDamage(player, dmg)
+    if not ACTIVE[player] then return nil end
+    local hp = HP[player] or 0
+    hp -= dmg
+    if hp <= 0 then
+        TekkaiService.Stop(player)
+        return "Broken"
+    else
+        HP[player] = hp
+        OverheadBarService.UpdateTekkai(player, hp, TekkaiConfig.BlockHP or 750)
+        return "Damaged"
+    end
+end
+
+if RunService:IsServer() then
+    Players.PlayerRemoving:Connect(cleanup)
+
+    RunService.Heartbeat:Connect(function(dt)
+        for player in pairs(ACTIVE) do
+            local amount = TekkaiService.GetDrainRate() * dt
+            if not StaminaService.Consume(player, amount) then
+                TekkaiService.Stop(player)
+            end
+        end
+    end)
+end
+
+return TekkaiService

--- a/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
@@ -26,6 +26,10 @@ local Rokushiki = {
             Hit = "rbxassetid://9117969717",
         },
     },
+    Tekkai = {
+        BlockHP = 750,
+        StaminaDrain = 10,
+    },
 }
 
 return Rokushiki

--- a/src/ServerScriptService/Combat/Tekkai.server.lua
+++ b/src/ServerScriptService/Combat/Tekkai.server.lua
@@ -1,0 +1,35 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Remotes = ReplicatedStorage:WaitForChild("Remotes")
+local CombatRemotes = Remotes:WaitForChild("Combat")
+local TekkaiEvent = CombatRemotes:WaitForChild("TekkaiEvent")
+
+local TekkaiService = require(ReplicatedStorage.Modules.Combat.TekkaiService)
+local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
+local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
+local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
+
+TekkaiEvent.OnServerEvent:Connect(function(player, start)
+    if start then
+        if StunService:IsStunned(player) or StunService:IsAttackerLocked(player) or BlockService.IsBlocking(player) then
+            TekkaiEvent:FireClient(player, false)
+            return
+        end
+        local char = player.Character
+        local tool = char and char:FindFirstChildOfClass("Tool")
+        if not tool or tool.Name ~= "Rokushiki" or not ToolConfig.ValidCombatTools[tool.Name] then
+            TekkaiEvent:FireClient(player, false)
+            return
+        end
+        if TekkaiService.Start(player) then
+            TekkaiEvent:FireAllClients(player, true)
+        else
+            TekkaiEvent:FireClient(player, false)
+        end
+    else
+        TekkaiService.Stop(player)
+        TekkaiEvent:FireAllClients(player, false)
+    end
+end)
+

--- a/src/ServerScriptService/Misc/RemoteSetup.server.lua
+++ b/src/ServerScriptService/Misc/RemoteSetup.server.lua
@@ -45,6 +45,7 @@ ensureEvent(combat, "PowerKickHit")
 ensureEvent(combat, "ShiganStart")
 ensureEvent(combat, "ShiganHit")
 ensureEvent(combat, "HakiEvent")
+ensureEvent(combat, "TekkaiEvent")
 
 -- Movement events
 local movement = ensureFolder(remotes, "Movement")


### PR DESCRIPTION
## Summary
- support a new Rokushiki move called **Tekkai**
- create client & server scripts and service for Tekkai
- extend overhead UI to show a special Tekkai bar
- drain stamina while Tekkai is active and disable movement
- update remote setup and config
- integrate with existing block logic

## Testing
- `No tests configured`

------
https://chatgpt.com/codex/tasks/task_e_6844b1d4dd18832d981f4543fbe48de2