### PR TITLE
Implement delayed Haki toggle with updated sound

### DIFF
--- a/src/ReplicatedStorage/Modules/Config/SoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/SoundConfig.lua
@@ -34,7 +34,7 @@ local SoundConfig = {
         },
 
         Haki = {
-                Activate = "rbxassetid://122809552011508",
+                Activate = "rbxassetid://979751563",
         },
 
 	UI = {

--- a/src/ServerScriptService/Combat/Haki.server.lua
+++ b/src/ServerScriptService/Combat/Haki.server.lua
@@ -13,17 +13,24 @@ local function broadcastState(player)
     HakiEvent:FireAllClients(player, active)
 end
 
+local pending = {}
+
 HakiEvent.OnServerEvent:Connect(function(player, enable)
     if typeof(enable) ~= "boolean" then return end
-    if enable then
-        if not HakiService.Toggle(player, true) then
-            HakiEvent:FireClient(player, false)
-            return
+    if pending[player] then return end
+    pending[player] = true
+    task.delay(1, function()
+        pending[player] = nil
+        if enable then
+            if not HakiService.Toggle(player, true) then
+                HakiEvent:FireClient(player, false)
+                return
+            end
+        else
+            HakiService.Toggle(player, false)
         end
-    else
-        HakiService.Toggle(player, false)
-    end
-    broadcastState(player)
+        broadcastState(player)
+    end)
 end)
 
 RunService.Heartbeat:Connect(function()


### PR DESCRIPTION
## Summary
- add 1 second delay before activating or deactivating Haki
- keep toggling from spamming with a pending flag
- update Haki activation sound ID to `rbxassetid://979751563`

## Testing
- `aftman install` *(fails: error sending request due to invalid peer certificate)*
- `rojo build default.project.json -o game.rbxlx` *(fails: `/root/.aftman/bin/rojo: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6844b3bb13c0832d814f159017a0ab30