### PR TITLE
Fix PowerPunch hitbox duration

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -98,7 +98,7 @@ local function performMove()
     local hitbox = HitboxClient.CastHitbox(
         MoveHitboxConfig.PowerPunch.Offset,
         MoveHitboxConfig.PowerPunch.Size,
-        MoveHitboxConfig.PowerPunch.Duration,
+        PowerPunchConfig.HitboxDuration,
         HitEvent,
         {dir},
         MoveHitboxConfig.PowerPunch.Shape,

--- a/src/ReplicatedStorage/Modules/Config/Tools/BasicCombat.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/BasicCombat.lua
@@ -14,7 +14,6 @@ local BasicCombat = {
         Hitbox = {
             Size = Vector3.new(6, 6, 7),
             Offset = CFrame.new(0, 0, -3.2),
-            Duration = 0.2,
             Shape = "Block",
         },
         Sound = {


### PR DESCRIPTION
## Summary
- remove duplicate Duration from PowerPunch hitbox config
- use `HitboxDuration` for hitbox travel time

## Testing
- `aftman install` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6844e7db1db0832db92ad57fb994c202