### PR TITLE
Fix invisible dash leaving overhead bars hidden

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -45,7 +45,9 @@ local function setCharacterInvisible(character, invisible, owner)
                 obj.Enabled = false
             else
                 local prev = originalGuiState[obj]
-                obj.Enabled = prev ~= nil and prev or obj.Enabled
+                if prev ~= nil then
+                    obj.Enabled = prev
+                end
                 originalGuiState[obj] = nil
             end
             if not invisible and owner and obj:IsA("BillboardGui") then


### PR DESCRIPTION
## Summary
- fix GUI state restoration after Rokushiki dash ends

## Testing
- `npx --yes @roblox/lua-style check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bcc5fd1c832db758a6461cde6aa1