### PR TITLE
Improve concasse movement

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -60,6 +60,12 @@ local function performMove(targetPos)
     currentHumanoid = humanoid
     prevWalkSpeed = humanoid.WalkSpeed
     prevJumpPower = humanoid.JumpPower
+    local prevAnchored = hrp.Anchored
+    local prevPlat = humanoid.PlatformStand
+    local prevAuto = humanoid.AutoRotate
+    humanoid.PlatformStand = true
+    humanoid.AutoRotate = false
+    hrp.Anchored = true
     humanoid.WalkSpeed = 0
     humanoid.JumpPower = 0
 
@@ -68,11 +74,13 @@ local function performMove(targetPos)
     local start = hrp.Position
     local dest = targetPos
     local dir = dest - start
-    local dist = dir.Magnitude
+    local horiz = Vector3.new(dir.X, 0, dir.Z)
+    local dist = horiz.Magnitude
     if dist > (cfg.Range or 65) then
-        dest = start + dir.Unit * (cfg.Range or 65)
+        horiz = horiz.Unit * (cfg.Range or 65)
         dist = (cfg.Range or 65)
     end
+    dest = start + horiz
     StartEvent:FireServer(dest)
 
     local height = dist * 0.5 + 25
@@ -86,6 +94,13 @@ local function performMove(targetPos)
         RunService.RenderStepped:Wait()
     end
     hrp.CFrame = CFrame.new(dest)
+    hrp.Anchored = prevAnchored
+    humanoid.PlatformStand = prevPlat
+    humanoid.AutoRotate = prevAuto
+
+    while humanoid.FloorMaterial == Enum.Material.Air do
+        RunService.RenderStepped:Wait()
+    end
 
     HitboxClient.CastHitbox(
         MoveHitboxConfig.Concasse.Offset,

--- a/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
@@ -52,7 +52,8 @@ local BlackLeg = {
         PerfectBlockable = true,
         Endlag = 0,
         Range = 65,
-        TravelSpeed = 10,
+        -- Increased travel speed for faster aerial movement
+        TravelSpeed = 30,
         HitboxDuration = 0.1,
         Cooldown = 12,
         Hitbox = {


### PR DESCRIPTION
## Summary
- speed up Concasse travel speed
- anchor player while moving to avoid jitter
- clamp destination to horizontal range
- wait to trigger hit until landing

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684628eb4260832db493a08c6e8ff6e9