### PR TITLE
Fix billboard state after RokuDash

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -50,7 +50,8 @@ local function setCharacterInvisible(character, invisible, owner)
                 end
                 originalGuiState[obj] = nil
             end
-            if not invisible and owner and obj:IsA("BillboardGui") then
+            -- Only update PlayerToHideFrom for the local player's own GUI
+            if not invisible and owner == player and obj:IsA("BillboardGui") then
                 pcall(function()
                     obj.PlayerToHideFrom = owner
                 end)


### PR DESCRIPTION
## Summary
- avoid overriding billboard `PlayerToHideFrom` for other players in RokuDash

## Testing
- `rojo build default.project.json -o build.rbxlx` *(fails: `bash: rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68462c8bdaa8832d85eda18109dfb4b1