### PR TITLE
Adjust Concasse timing

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -84,7 +84,7 @@ local function performMove(targetPos)
     StartEvent:FireServer(dest)
 
     local height = dist * 0.5 + 25
-    local travelTime = dist / (cfg.TravelSpeed or 10)
+    local travelTime = (cfg.TravelTime or (dist / (cfg.TravelSpeed or 10)))
     local startTime = tick()
     while tick() - startTime < travelTime do
         local t = (tick() - startTime) / travelTime

--- a/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
@@ -52,8 +52,8 @@ local BlackLeg = {
         PerfectBlockable = true,
         Endlag = 0,
         Range = 65,
-        -- Increased travel speed for faster aerial movement
-        TravelSpeed = 30,
+        -- Fixed travel time for consistent speed across distances
+        TravelTime = 1,
         HitboxDuration = 0.1,
         Cooldown = 12,
         Hitbox = {

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -108,7 +108,7 @@ StartEvent.OnServerEvent:Connect(function(player, targetPos)
         humanoid.AutoRotate = false
 
         local height = dist * 0.5 + 25
-        local travelTime = dist / (ConcasseConfig.TravelSpeed or 10)
+        local travelTime = (ConcasseConfig.TravelTime or (dist / (ConcasseConfig.TravelSpeed or 10)))
         local startTime = tick()
         while tick() - startTime < travelTime do
             local t = (tick() - startTime) / travelTime


### PR DESCRIPTION
## Summary
- keep Concasse travel time constant by adding `TravelTime` setting
- apply travel time in client/server scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68464137e404832db83003a2a60a93a0