### PR TITLE
Refactor combat animation handling

### DIFF
--- a/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
@@ -15,14 +15,10 @@ CombatConfig.M1 = {
         M1StunDuration = 0.5,
 	M1_5StunDuration = 1.5,
 
-	KnockbackDistance = 25,
-	KnockbackDuration = 0.4,
+        KnockbackDistance = 25,
+        KnockbackDuration = 0.4,
         KnockbackLift = 3,
         KnockbackDirection = "AttackerFacingDirection",
-
-	HitboxSize = Vector3.new(4, 5, 4),
-	HitboxOffset = CFrame.new(0, 0, -2.4),
-	HitboxDuration = 0.1,
 
 	HitSoundDelay = 0.05,
 	MissSoundDelay = 0.05,

--- a/src/ReplicatedStorage/Modules/Effects/AnimationUtils.lua
+++ b/src/ReplicatedStorage/Modules/Effects/AnimationUtils.lua
@@ -1,0 +1,26 @@
+--ReplicatedStorage.Modules.Effects.AnimationUtils
+
+local AnimationUtils = {}
+
+function AnimationUtils.PlayAnimation(animator: Instance, animId: any, priority: Enum.AnimationPriority?)
+    if not animator or not animId then
+        return nil
+    end
+
+    local id = tostring(animId)
+    if not id:match("^rbxassetid://") then
+        id = "rbxassetid://" .. id
+    end
+
+    local animation = Instance.new("Animation")
+    animation.AnimationId = id
+
+    local track = animator:LoadAnimation(animation)
+    track.Priority = priority or Enum.AnimationPriority.Action
+    track.Looped = false
+    track:Play()
+
+    return track
+end
+
+return AnimationUtils


### PR DESCRIPTION
## Summary
- extract reusable `AnimationUtils` for playing animations
- use AnimationUtils in StunService and CombatService
- remove unused M1 hitbox settings from CombatConfig

## Testing
- `./rojo_bin/rojo build default.project.json -o dev.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684652aa4078832d9577b664e60eac77