### PR TITLE
Optimize move startup waits

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/JumpController.lua
+++ b/src/ReplicatedStorage/Modules/Client/JumpController.lua
@@ -16,7 +16,7 @@ local DEBUG = Config.GameSettings.DebugEnabled
 
 local jumpBlockedUntil = 0
 local character, humanoid
-local heartbeatConn
+local cooldownTask
 
 -- 🔒 Forcefully disable jumping
 local function blockJump()
@@ -39,21 +39,18 @@ function JumpController.StartCooldown(duration)
 	jumpBlockedUntil = tick() + time
 	if DEBUG then print("[JumpController] Jump cooldown started:", time, "s") end
 
-	if heartbeatConn then
-		heartbeatConn:Disconnect()
-	end
+        if cooldownTask then
+                task.cancel(cooldownTask)
+                cooldownTask = nil
+        end
 
-	heartbeatConn = RunService.Heartbeat:Connect(function()
-		if tick() < jumpBlockedUntil then
-			blockJump()
-		else
-			restoreJump()
-			if heartbeatConn then
-				heartbeatConn:Disconnect()
-				heartbeatConn = nil
-			end
-		end
-	end)
+        blockJump()
+        cooldownTask = task.delay(time, function()
+                if tick() >= jumpBlockedUntil then
+                        restoreJump()
+                        cooldownTask = nil
+                end
+        end)
 end
 
 -- 📦 Handle jump input

--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -27,6 +27,13 @@ local prevWalkSpeed
 local prevJumpPower
 local currentHumanoid
 
+-- Wait until the humanoid touches the ground without busy-waiting
+local function waitForLanding(hum)
+    while hum and hum.Parent and hum.FloorMaterial == Enum.Material.Air do
+        hum:GetPropertyChangedSignal("FloorMaterial"):Wait()
+    end
+end
+
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
 
@@ -99,9 +106,7 @@ local function performMove(targetPos)
     humanoid.PlatformStand = prevPlat
     humanoid.AutoRotate = prevAuto
 
-    while humanoid.FloorMaterial == Enum.Material.Air do
-        RunService.RenderStepped:Wait()
-    end
+    waitForLanding(humanoid)
 
     HitboxClient.CastHitbox(
         MoveHitboxConfig.Concasse.Offset,

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
@@ -68,10 +68,8 @@ local function performMove()
     playAnimation(animator, Animations.SpecialMoves.PowerKick)
     StartEvent:FireServer()
 
-    local startTime = tick()
-    while tick() - startTime < cfg.Startup do
-        RunService.RenderStepped:Wait()
-    end
+    -- Straightforward delay before the hitbox spawns
+    task.wait(cfg.Startup)
 
     local dir = hrp.CFrame.LookVector
     HitboxClient.CastHitbox(

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -88,10 +88,8 @@ local function performMove()
     playAnimation(animator, Animations.SpecialMoves.PowerPunch)
     StartEvent:FireServer()
 
-    local startTime = tick()
-    while tick() - startTime < cfg.Startup do
-        RunService.RenderStepped:Wait()
-    end
+    -- Wait for startup without a busy loop
+    task.wait(cfg.Startup)
 
     -- Cast the hitbox while movement is still locked
     local dir = hrp.CFrame.LookVector

--- a/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
@@ -67,10 +67,8 @@ local function performMove()
     playAnimation(animator, Animations.SpecialMoves.Shigan)
     StartEvent:FireServer()
 
-    local startTime = tick()
-    while tick() - startTime < cfg.Startup do
-        RunService.RenderStepped:Wait()
-    end
+    -- No checks needed during startup, simple wait suffices
+    task.wait(cfg.Startup)
 
     local dir = hrp.CFrame.LookVector
     HitboxClient.CastHitbox(

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
@@ -68,10 +68,8 @@ local function performMove()
     playAnimation(animator, Animations.SpecialMoves.PowerKick)
     StartEvent:FireServer()
 
-    local startTime = tick()
-    while tick() - startTime < cfg.Startup do
-        RunService.RenderStepped:Wait()
-    end
+    -- No extra logic during startup, so a simple timed wait is fine
+    task.wait(cfg.Startup)
 
     local dir = hrp.CFrame.LookVector
     HitboxClient.CastHitbox(


### PR DESCRIPTION
## Summary
- replace busy RenderStepped loops with simple waits in move startup logic
- add event-based landing wait for ConcasseClient

## Testing
- `rojo build default.project.json -o test.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684662d3a3c0832dbfa6cd530748fb44