### PR TITLE
Adjust Concasse flight timing

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -90,13 +90,13 @@ local function performMove(targetPos)
     dest = start + horiz
     StartEvent:FireServer(dest)
 
-    local height = math.max(dist * 0.5 + 25, 15)
-    -- Calculate travel time from a constant travel speed with a floor so short
-    -- distances don't feel instantaneous
-    local travelTime = math.max(
-        cfg.TravelTime or (dist / (cfg.TravelSpeed or 10)),
-        cfg.MinTravelTime or 0
-    )
+    local height = math.max(dist * 0.5 + 25, 20)
+    -- Travel time scales between configured min and max based on distance
+    local range = cfg.Range or 65
+    local ratio = math.clamp(dist / range, 0, 1)
+    local minTime = cfg.MinTravelTime or 0
+    local maxTime = cfg.MaxTravelTime or minTime
+    local travelTime = minTime + (maxTime - minTime) * ratio
     local startTime = tick()
     while tick() - startTime < travelTime do
         local t = (tick() - startTime) / travelTime

--- a/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/BlackLeg.lua
@@ -46,17 +46,18 @@ local BlackLeg = {
     },
     Concasse = {
         Damage = 75,
-        StunDuration = 1.5,
-        Startup = 0,
+        StunDuration = 1,
+        Startup = 0.2,
         HyperArmor = false,
         GuardBreak = false,
         PerfectBlockable = true,
-        Endlag = 0,
+        Endlag = 0.1,
         Range = 65,
         -- Constant travel speed for consistent feel across distances
         TravelSpeed = 65,
-        -- Minimum time before landing to prevent instant "teleport" feel
-        MinTravelTime = 0.4,
+        -- Travel time scales with distance
+        MinTravelTime = 1,
+        MaxTravelTime = 2,
         HitboxDuration = 0.1,
         Cooldown = 12,
         Hitbox = {

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -110,13 +110,12 @@ StartEvent.OnServerEvent:Connect(function(player, targetPos)
         humanoid.PlatformStand = true
         humanoid.AutoRotate = false
 
-        -- Travel time is derived from a constant travel speed so the
-        -- move feels the same at any distance. Enforce a minimum so
-        -- short distances don't finish instantly.
-        local travelTime = math.max(
-            ConcasseConfig.TravelTime or (dist / (ConcasseConfig.TravelSpeed or 10)),
-            ConcasseConfig.MinTravelTime or 0
-        )
+        -- Travel time scales between configured min/max based on distance
+        local range = ConcasseConfig.Range or 65
+        local ratio = math.clamp(dist / range, 0, 1)
+        local minTime = ConcasseConfig.MinTravelTime or 0
+        local maxTime = ConcasseConfig.MaxTravelTime or minTime
+        local travelTime = minTime + (maxTime - minTime) * ratio
 
         task.delay(travelTime, function()
             hrp.CFrame = CFrame.new(dest)


### PR DESCRIPTION
## Summary
- tune Concasse configuration to feel slower at short range
- update client/server travel time calculation

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_6846e5c03df8832d88cbfc63268696ba