### PR TITLE
Fix sendStatus nil call

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -31,6 +31,9 @@ local AttackerLockouts = {}
 local HitReservations = {}
 local ActiveAnimations = {}
 
+-- forward declaration for sendStatus so callbacks defined below can reference it
+local sendStatus
+
 local function cleanupPlayer(player)
     local data = StunnedPlayers[player]
     if data then
@@ -60,7 +63,7 @@ if RunService:IsServer() then
     end)
 end
 
-local function sendStatus(player)
+sendStatus = function(player)
     if RunService:IsServer() and StunStatusEvent and player then
         local data = {
             Stunned = StunnedPlayers[player] ~= nil,


### PR DESCRIPTION
## Summary
- forward declare `sendStatus` so StunService connections don't reference a nil value

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_6846f305a800832db41083b028e7d881