### PR TITLE
Fix TempestKick VFX replication and Concasse movement

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -67,12 +67,10 @@ local function performMove(targetPos)
     currentHumanoid = humanoid
     prevWalkSpeed = humanoid.WalkSpeed
     prevJumpPower = humanoid.JumpPower
-    local prevAnchored = hrp.Anchored
     local prevPlat = humanoid.PlatformStand
     local prevAuto = humanoid.AutoRotate
     humanoid.PlatformStand = true
     humanoid.AutoRotate = false
-    hrp.Anchored = true
     humanoid.WalkSpeed = 0
     humanoid.JumpPower = 0
 
@@ -106,7 +104,6 @@ local function performMove(targetPos)
         RunService.RenderStepped:Wait()
     end
     hrp.CFrame = CFrame.new(dest)
-    hrp.Anchored = prevAnchored
     humanoid.PlatformStand = prevPlat
     humanoid.AutoRotate = prevAuto
 

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
@@ -9,6 +9,7 @@ local RunService = game:GetService("RunService")
 local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
 local StartEvent = CombatRemotes:WaitForChild("TempestKickStart")
 local HitEvent = CombatRemotes:WaitForChild("TempestKickHit")
+local VFXEvent = CombatRemotes:WaitForChild("TempestKickVFX")
 
 local Animations = require(ReplicatedStorage.Modules.Animations.Combat)
 local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
@@ -125,5 +126,27 @@ end
 function TempestKick.OnInputEnded()
     -- move cannot be cancelled
 end
+
+-- Play VFX for other players when the server notifies us
+VFXEvent.OnClientEvent:Connect(function(kickPlayer, startCF)
+    if kickPlayer == Players.LocalPlayer then return end
+    if typeof(startCF) ~= "CFrame" then return end
+
+    local dir = startCF.LookVector
+    local hitbox = HitboxClient.CastHitbox(
+        MoveHitboxConfig.TempestKick.Offset,
+        MoveHitboxConfig.TempestKick.Size,
+        TempestKickConfig.HitboxDuration,
+        nil,
+        {dir},
+        MoveHitboxConfig.TempestKick.Shape,
+        false,
+        TempestKickConfig.HitboxDistance,
+        false
+    )
+    if hitbox then
+        TempestKickVFX.Create(hitbox)
+    end
+end)
 
 return TempestKick

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -99,14 +99,10 @@ StartEvent.OnServerEvent:Connect(function(player, targetPos)
         end
         local dest = start + horiz
 
-        -- Temporarily anchor to keep the character stable while the
-        -- client animates the actual movement. The server simply
-        -- teleports to the final position after the travel time to
-        -- avoid fighting against client-side interpolation.
-        local prevAnchor = hrp.Anchored
+        -- Allow the client to control the movement so other players see it
+        -- by only disabling platform stand and autorotate.
         local prevPlat = humanoid.PlatformStand
         local prevAuto = humanoid.AutoRotate
-        hrp.Anchored = true
         humanoid.PlatformStand = true
         humanoid.AutoRotate = false
 
@@ -118,8 +114,9 @@ StartEvent.OnServerEvent:Connect(function(player, targetPos)
         local travelTime = minTime + (maxTime - minTime) * ratio
 
         task.delay(travelTime, function()
-            hrp.CFrame = CFrame.new(dest)
-            hrp.Anchored = prevAnchor
+            if hrp.Parent then
+                hrp.CFrame = CFrame.new(dest)
+            end
             humanoid.PlatformStand = prevPlat
             humanoid.AutoRotate = prevAuto
         end)

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -4,6 +4,7 @@ local Remotes = ReplicatedStorage:WaitForChild("Remotes")
 local CombatRemotes = Remotes:WaitForChild("Combat")
 local StartEvent = CombatRemotes:WaitForChild("TempestKickStart")
 local HitEvent = CombatRemotes:WaitForChild("TempestKickHit")
+local VFXEvent = CombatRemotes:WaitForChild("TempestKickVFX")
 
 local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
 local TempestKickConfig = AbilityConfig.Rokushiki.TempestKick
@@ -87,6 +88,10 @@ StartEvent.OnServerEvent:Connect(function(player)
     end
     playAnimation(humanoid, AnimationData.SpecialMoves.PowerKick)
     if DEBUG then print("[TempestKick] Animation triggered") end
+    local hrp = char:FindFirstChild("HumanoidRootPart")
+    if hrp then
+        VFXEvent:FireAllClients(player, hrp.CFrame)
+    end
 end)
 
 HitEvent.OnServerEvent:Connect(function(player, targets, dir)

--- a/src/ServerScriptService/Misc/RemoteSetup.server.lua
+++ b/src/ServerScriptService/Misc/RemoteSetup.server.lua
@@ -48,6 +48,7 @@ ensureEvent(combat, "ShiganStart")
 ensureEvent(combat, "ShiganHit")
 ensureEvent(combat, "TempestKickStart")
 ensureEvent(combat, "TempestKickHit")
+ensureEvent(combat, "TempestKickVFX")
 ensureEvent(combat, "HakiEvent")
 ensureEvent(combat, "TekkaiEvent")
 


### PR DESCRIPTION
## Summary
- add `TempestKickVFX` remote event
- broadcast TempestKick VFX to all clients from the server
- play the Tempest Kick VFX for other players when notified
- remove anchoring from Concasse so movement replicates

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684705f21f00832d92239fd3097eab19