### PR TITLE
Fix Tempest Kick VFX on remote players

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
@@ -132,17 +132,17 @@ VFXEvent.OnClientEvent:Connect(function(kickPlayer, startCF)
     if kickPlayer == Players.LocalPlayer then return end
     if typeof(startCF) ~= "CFrame" then return end
 
-    local dir = startCF.LookVector
     local hitbox = HitboxClient.CastHitbox(
         MoveHitboxConfig.TempestKick.Offset,
         MoveHitboxConfig.TempestKick.Size,
         TempestKickConfig.HitboxDuration,
         nil,
-        {dir},
+        nil,
         MoveHitboxConfig.TempestKick.Shape,
         false,
         TempestKickConfig.HitboxDistance,
-        false
+        false,
+        startCF
     )
     if hitbox then
         TempestKickVFX.Create(hitbox)


### PR DESCRIPTION
## Summary
- allow `HitboxClient.CastHitbox` to spawn hitboxes at an arbitrary CFrame
- disable hit detection when only visual effects are required
- use new feature in `TempestKickClient` so other players' effects show in the right place

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847086378d4832da0483e05dc4ff733