### PR TITLE
Limit knockback slide duration

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -111,9 +111,10 @@ end
                 * a string/number representing a custom animation id to play
 ]]
 --[[
-    @param preserveVelocity boolean? When true, horizontal velocity will not be
+    @param preserveVelocity boolean|number? When true, horizontal velocity will not be
     zeroed during the stun. Used for knockback moves so the target continues
-    moving while stunned.
+    moving while stunned. If a number is supplied, velocity is preserved only for
+    the given duration in seconds.
 ]]
 function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker, preserveVelocity)
         local targetPlayer = getPlayer(targetHumanoid)
@@ -131,6 +132,12 @@ function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker, p
 
     local prevWalkSpeed = targetHumanoid.WalkSpeed
     local prevJumpPower = targetHumanoid.JumpPower
+
+    local preserveVelocityDuration
+    if typeof(preserveVelocity) == "number" then
+        preserveVelocityDuration = preserveVelocity
+        preserveVelocity = true
+    end
 
     local existing = StunnedPlayers[targetPlayer]
     if existing then
@@ -161,6 +168,15 @@ function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker, p
         hrp.AssemblyAngularVelocity = Vector3.new(0, 0, 0)
         if preserveVelocity then
             hrp:SetAttribute("StunPreserveVelocity", true)
+            if preserveVelocityDuration then
+                task.delay(preserveVelocityDuration, function()
+                    local data = StunnedPlayers[targetPlayer]
+                    if data and data.HRP == hrp then
+                        hrp:SetAttribute("StunPreserveVelocity", nil)
+                        data.PreserveVelocity = false
+                    end
+                end)
+            end
         end
     end
 

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -175,7 +175,8 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 hitLanded = true
 
                 local stunDuration = isFinal and CombatConfig.M1.M1_5StunDuration or CombatConfig.M1.M1StunDuration
-                StunService:ApplyStun(enemyHumanoid, stunDuration, isFinal, player, isFinal)
+                local preserve = isFinal and CombatConfig.M1.KnockbackDuration or false
+                StunService:ApplyStun(enemyHumanoid, stunDuration, isFinal, player, preserve)
 
                 -- 💥 Knockback logic
                 if isFinal then


### PR DESCRIPTION
## Summary
- allow `StunService:ApplyStun` to accept a numeric `preserveVelocity` duration
- end the knockback slide after the knockback duration in M1 combos

## Testing
- `./rojo-bin/rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684712849394832dab28a1ab0e9962e6