### PR TITLE
Implement back hit block cancel

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -101,12 +101,22 @@ end
 -- ⚔️ Handles damage application to a blocking player
 -- Returns: "Perfect", "Damaged", "Broken", or nil (not blocking)
 -- @param isBlockBreaker boolean? whether the attack ignores blocking
-function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker)
+-- @param attackerRoot Instance? HumanoidRootPart of the attacking player
+function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker, attackerRoot)
        if TekkaiService.IsActive(player) then
                return TekkaiService.ApplyDamage(player, damage)
        end
 
        if not BlockingPlayers[player] then return nil end
+
+       local defenderRoot = player.Character and player.Character:FindFirstChild("HumanoidRootPart")
+       if attackerRoot and defenderRoot then
+               local relative = (attackerRoot.Position - defenderRoot.Position).Unit
+               if relative:Dot(defenderRoot.CFrame.LookVector) < 0 then
+                       BlockService.StopBlocking(player)
+                       return nil
+               end
+       end
 
        local hp = BlockHP[player] or 0
        local timeSinceStart = tick() - (PerfectBlockTimers[player] or 0)

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -142,7 +142,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 if not StunService:CanBeHitBy(player, enemyPlayer) then continue end
                 if not ShouldApplyHit(player, enemyPlayer) then continue end
 
-               local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, damage, false)
+               local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, damage, false, hrp)
                 if blockResult == "Perfect" then
                         blockHit = true
                         StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, player)

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -162,7 +162,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
             continue
         end
 
-        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, ConcasseConfig.Damage, false)
+        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, ConcasseConfig.Damage, false, hrp)
         if blockResult == "Perfect" then
             if DEBUG then print("[Concasse] Perfect block by", enemyPlayer.Name) end
             stopAnimation(humanoid)

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -140,7 +140,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             continue
         end
 
-        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, cfg.DamagePerHit, false)
+        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, cfg.DamagePerHit, false, hrp)
         if blockResult == "Perfect" then
             if DEBUG then print("[PartyTableKick] Perfect block by", enemyPlayer.Name) end
             blockHit = true

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -126,12 +126,12 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if PowerKickConfig.GuardBreak then
             if PowerKickConfig.PerfectBlockable then
                 local dmg = BlockService.GetBlockHP(enemyPlayer)
-                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, dmg, false)
+                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, dmg, false, hrp)
             else
-                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerKickConfig.Damage, true)
+                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerKickConfig.Damage, true, hrp)
             end
         else
-            blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerKickConfig.Damage, false)
+            blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerKickConfig.Damage, false, hrp)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerKick] Perfect block by", enemyPlayer.Name) end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -135,12 +135,12 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         if PowerPunchConfig.GuardBreak then
             if PowerPunchConfig.PerfectBlockable then
                 local dmg = BlockService.GetBlockHP(enemyPlayer)
-                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, dmg, false)
+                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, dmg, false, hrp)
             else
-                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerPunchConfig.Damage, true)
+                blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerPunchConfig.Damage, true, hrp)
             end
         else
-            blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerPunchConfig.Damage, false)
+            blockResult = BlockService.ApplyBlockDamage(enemyPlayer, PowerPunchConfig.Damage, false, hrp)
         end
         if blockResult == "Perfect" then
             if DEBUG then print("[PowerPunch] Perfect block by", enemyPlayer.Name) end

--- a/src/ServerScriptService/Combat/Shigan.server.lua
+++ b/src/ServerScriptService/Combat/Shigan.server.lua
@@ -117,7 +117,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
             continue
         end
 
-        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, ShiganConfig.Damage, false)
+        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, ShiganConfig.Damage, false, hrp)
         if blockResult == "Perfect" then
             if DEBUG then print("[Shigan] Perfect block by", enemyPlayer.Name) end
             stopAnimation(humanoid)

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -136,7 +136,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
             continue
         end
 
-        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, TempestKickConfig.Damage, false)
+        local blockResult = BlockService.ApplyBlockDamage(enemyPlayer, TempestKickConfig.Damage, false, hrp)
         if blockResult == "Perfect" then
             if DEBUG then print("[TempestKick] Perfect block by", enemyPlayer.Name) end
             stopAnimation(humanoid)


### PR DESCRIPTION
## Summary
- cancel blocking if the attacker is behind the defender
- pass the attacker's root part to `ApplyBlockDamage`

## Testing
- `aftman install` *(fails: invalid peer certificate)*
- `rojo build default.project.json -o game.rbxlx` *(not run due to missing Rojo binary)*

------
https://chatgpt.com/codex/tasks/task_e_684724d30a3c832d8afb9202816d0de6