### PR TITLE
Fix orientation for PartyTableKick VFX

### DIFF
--- a/src/ReplicatedStorage/Modules/Effects/PartyTableKickVFX.lua
+++ b/src/ReplicatedStorage/Modules/Effects/PartyTableKickVFX.lua
@@ -17,7 +17,16 @@ function PartyTableKickVFX.Create(parent: Instance)
     local cfg = Config.VFX.PartyTableKickVFX or {}
     local vfx = TEMPLATE:Clone()
     vfx.Anchored = false
-    vfx.CFrame = parent.CFrame * CFrame.new(cfg.Position.X or 0, cfg.Position.Y or 0, cfg.Position.Z or 0)
+
+    -- The hitbox for PartyTableKick is rotated 90 degrees on the Z axis. When
+    -- the VFX is parented to that hitbox it inherits the same rotation which
+    -- results in the effect playing sideways. If the parent is the hitbox,
+    -- counter rotate so the effect appears upright.
+    local cf = parent.CFrame * CFrame.new(cfg.Position.X or 0, cfg.Position.Y or 0, cfg.Position.Z or 0)
+    if parent.Name == "ClientHitbox" then
+        cf = cf * CFrame.Angles(0, 0, math.rad(-90))
+    end
+    vfx.CFrame = cf
     vfx.Size = Vector3.new(cfg.Scale.X or 1, cfg.Scale.Y or 1, cfg.Scale.Z or 1)
     vfx.Parent = parent
 


### PR DESCRIPTION
## Summary
- rotate the PartyTableKick VFX back upright when attached to the sideways hitbox

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `bash: rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68473d473550832dbec74b82a37f5624