### PR TITLE
Fix movement during stun

### DIFF
--- a/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
+++ b/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
@@ -1,6 +1,9 @@
 -- StarterCharacterScripts > AntiRagdollController.lua
 
 local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 
 local character = script.Parent
 local humanoid = character:WaitForChild("Humanoid")
@@ -39,10 +42,10 @@ local lastCorrection = 0
 RunService.Heartbeat:Connect(function()
 	if not humanoid or not hrp then return end
 
-	-- Ensure autorotate is always on
-	if humanoid.AutoRotate == false then
-		humanoid.AutoRotate = true
-	end
+    -- Ensure autorotate is always on when not stunned
+    if humanoid.AutoRotate == false and not StunStatusClient.IsStunned() then
+            humanoid.AutoRotate = true
+    end
 
 	-- Reset invalid physics states on delay
 	if tick() - lastCorrection >= CORRECTION_DELAY then


### PR DESCRIPTION
## Summary
- keep player autorotation disabled when stunned
- dependency: new require for StunStatusClient in AntiRagdollController

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_6847408ae534832d9368244232da828a