### PR TITLE
Fix Tekkai locking jump

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
@@ -11,6 +11,7 @@ local TekkaiEvent = CombatRemotes:WaitForChild("TekkaiEvent")
 local Animations = require(ReplicatedStorage.Modules.Animations.Combat)
 local AbilityConfig = require(ReplicatedStorage.Modules.Config.AbilityConfig)
 local TekkaiConfig = AbilityConfig.Rokushiki.Tekkai or {}
+local Config = require(ReplicatedStorage.Modules.Config.Config)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 local BlockClient = require(ReplicatedStorage.Modules.Combat.BlockClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
@@ -49,8 +50,8 @@ TekkaiEvent.OnClientEvent:Connect(function(tekkaiPlayer, state)
     if not humanoid then return end
     if state then
         active = true
-        prevWalk = humanoid.WalkSpeed
-        prevJump = humanoid.JumpPower
+        if not prevWalk then prevWalk = humanoid.WalkSpeed end
+        if not prevJump then prevJump = humanoid.JumpPower end
         humanoid.WalkSpeed = 0
         humanoid.JumpPower = 0
         track = playAnimation(animator, Animations.Blocking.TekkaiHold)
@@ -61,8 +62,8 @@ TekkaiEvent.OnClientEvent:Connect(function(tekkaiPlayer, state)
             track:Destroy()
             track = nil
         end
-        humanoid.WalkSpeed = prevWalk or humanoid.WalkSpeed
-        humanoid.JumpPower = prevJump or humanoid.JumpPower
+        humanoid.WalkSpeed = prevWalk or Config.GameSettings.DefaultWalkSpeed
+        humanoid.JumpPower = prevJump or Config.GameSettings.DefaultJumpPower
         prevWalk = nil
         prevJump = nil
     end
@@ -79,6 +80,11 @@ function Tekkai.OnInputBegan(input, gp)
     if not ToolController.IsValidCombatTool() then return end
     if StaminaService.GetStamina(Players.LocalPlayer) <= 0 then return end
 
+    local _, humanoid = getCharacter()
+    if humanoid then
+        prevWalk = humanoid.WalkSpeed
+        prevJump = humanoid.JumpPower
+    end
     MovementClient.StopSprint()
     TekkaiEvent:FireServer(true)
 end

--- a/src/ReplicatedStorage/Modules/Combat/TekkaiService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/TekkaiService.lua
@@ -63,9 +63,15 @@ function TekkaiService.Stop(player)
     local humanoid = char and char:FindFirstChildOfClass("Humanoid")
 
     local prev = PREV_MOVEMENT[player]
-    if humanoid and prev then
-        humanoid.WalkSpeed = prev.Walk or humanoid.WalkSpeed
-        humanoid.JumpPower = prev.Jump or humanoid.JumpPower
+    if humanoid then
+        if prev then
+            humanoid.WalkSpeed = prev.Walk or humanoid.WalkSpeed
+            humanoid.JumpPower = prev.Jump or humanoid.JumpPower
+        else
+            local Config = require(ReplicatedStorage.Modules.Config.Config)
+            humanoid.WalkSpeed = Config.GameSettings.DefaultWalkSpeed
+            humanoid.JumpPower = Config.GameSettings.DefaultJumpPower
+        end
     end
 
     OverheadBarService.SetTekkaiActive(player, false)


### PR DESCRIPTION
## Summary
- store walk/jump states when activating Tekkai to ensure they're restored
- restore default values if previous states are missing

## Testing
- `rojo build default.project.json -o out.rbxl` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68474358c5a4832d8eb4f12cd0581c07