### PR TITLE
Fix dashing after getting hit

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -24,6 +24,23 @@ local DASH_KEY = Enum.KeyCode.Q
 local currentTrack = nil
 local dashConn = nil
 
+-- Immediately stop any active dash and clear velocity
+function DashClient.CancelDash()
+    if dashConn then
+        dashConn:Disconnect()
+        dashConn = nil
+    end
+    local character, humanoid, _, hrp = getCharacterComponents()
+    if hrp then
+        local v = hrp.AssemblyLinearVelocity
+        hrp.AssemblyLinearVelocity = Vector3.new(0, v.Y, 0)
+    end
+    if humanoid then
+        humanoid.AutoRotate = true
+    end
+end
+-- Cancel active dash on stun
+
 -- Store original Enabled states for Gui objects so we can restore them
 local originalGuiState = setmetatable({}, {__mode = "k"})
 local originalHidePlayer = setmetatable({}, {__mode = "k"})

--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -44,6 +44,9 @@ local StunStatusEvent = Stun:WaitForChild("StunStatusRequestEvent")
 -- Update stun status using the provided helper instead of overwriting the API
 StunStatusEvent.OnClientEvent:Connect(function(data)
         StunStatusClient.SetStatus(data.Stunned, data.AttackerLock)
+        if data.Stunned then
+                DashClient.CancelDash()
+        end
 end)
 
 -- 🔗 Tool event connection


### PR DESCRIPTION
## Summary
- stop dash movement when a player becomes stunned
- cancel dash on stun events so players can't dash away

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_6847436614b0832d918751d6ee34688d