### PR TITLE
Fix HP regen by disabling default Roblox script

### DIFF
--- a/src/StarterPlayer/StarterCharacterScripts/Health.client.lua
+++ b/src/StarterPlayer/StarterCharacterScripts/Health.client.lua
@@ -1,0 +1,4 @@
+-- StarterCharacterScripts > Health
+-- Overrides Roblox's default Health script to disable automatic regeneration.
+
+-- This script intentionally left blank. Custom health regen is handled on the server.


### PR DESCRIPTION
## Summary
- stop Roblox's default health script from interfering with our custom HP regen

## Testing
- `rojo build default.project.json -o build.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684748147ea0832d9015c2b2d1fc964e