### PR TITLE
Fix move cooldown UI with prefixed elements

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -20,6 +20,7 @@ local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local KEY = Enum.KeyCode.T
 local active = false
@@ -192,6 +193,7 @@ function Concasse.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, ConcasseConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     StunStatusClient.LockFor(ConcasseConfig.Startup + (ConcasseConfig.Endlag or 0))

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -22,6 +22,7 @@ local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local PartyTableKickVFX = require(ReplicatedStorage.Modules.Effects.PartyTableKickVFX)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
@@ -178,6 +179,7 @@ function PartyTableKick.OnInputBegan(input, gp)
     held = true
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, cfg.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = cfg.Startup + cfg.Duration + (cfg.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
@@ -20,6 +20,7 @@ local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -109,6 +110,7 @@ function PowerKick.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, PowerKickConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = PowerKickConfig.Startup + (PowerKickConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -22,6 +22,7 @@ local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -135,6 +136,7 @@ function PowerPunch.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, PowerPunchConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = PowerPunchConfig.Startup + (PowerPunchConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
@@ -18,6 +18,7 @@ local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClie
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HitboxClient = require(ReplicatedStorage.Modules.Combat.HitboxClient)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -106,6 +107,7 @@ function Shigan.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, ShiganConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = ShiganConfig.Startup + (ShiganConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
@@ -17,6 +17,7 @@ local SoundServiceUtils = require(ReplicatedStorage.Modules.Effects.SoundService
 local TeleportVFX = require(ReplicatedStorage.Modules.Effects.TeleportVFX)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local KEY = Enum.KeyCode.T
 local active = false
@@ -49,6 +50,7 @@ function Teleport.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, TeleportConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = (TeleportConfig.Startup or 0) + (TeleportConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
@@ -22,6 +22,7 @@ local TempestKickVFX = require(ReplicatedStorage.Modules.Effects.TempestKickVFX)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -115,6 +116,7 @@ function TempestKick.OnInputBegan(input, gp)
 
     active = true
     lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, TempestKickConfig.Cooldown or 0)
 
     MovementClient.StopSprint()
     local lockTime = TempestKickConfig.Startup + (TempestKickConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
+++ b/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
@@ -1,0 +1,120 @@
+--ReplicatedStorage.Modules.UI.MoveListManager
+
+local MoveListManager = {}
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local player = Players.LocalPlayer
+local playerGui = player:WaitForChild("PlayerGui")
+
+-- add default keybinds including Q, F and J which are universal
+local keys = {"C","Z","X","T","R","E","Q","F","J"}
+local entries = {}
+
+local function populateEntries()
+    local screenGui = playerGui:FindFirstChild("PlayerGUI")
+    if not screenGui then return end
+    local moveList = screenGui:FindFirstChild("MoveList")
+    if not moveList then return end
+
+    for _, key in ipairs(keys) do
+        if not entries[key] then
+            local container = moveList:FindFirstChild(key)
+            if not container then
+                local suffix = "-" .. key
+                for _, child in ipairs(moveList:GetChildren()) do
+                    if child.Name:sub(-#suffix) == suffix then
+                        container = child
+                        break
+                    end
+                end
+            end
+            if container then
+                local bar = container:FindFirstChild("Cooldown")
+                local timer = container:FindFirstChild("Timer")
+                local move = container:FindFirstChild("Move")
+                entries[key] = {
+                    bar = bar,
+                    timer = timer,
+                    move = move,
+                    base = bar and bar.Size,
+                    color = move and move.TextColor3,
+                }
+            end
+        end
+    end
+end
+
+local function getEntry(letter)
+    if not entries[letter] or entries[letter] and not entries[letter].bar then
+        populateEntries()
+    end
+    return entries[letter]
+end
+
+function MoveListManager.StartCooldown(letter, duration)
+    local entry = getEntry(letter)
+    if not entry or not entry.bar then return end
+
+    if entry.conn then
+        entry.conn:Disconnect()
+        entry.conn = nil
+    end
+
+    local bar = entry.bar
+    local timer = entry.timer
+    local move = entry.move
+    local base = entry.base
+    local defaultColor = entry.color
+
+    if duration <= 0 then
+        if bar then bar.Visible = false end
+        if timer then timer.Text = "" end
+        if move and defaultColor then move.TextColor3 = defaultColor end
+        return
+    end
+
+    if move and defaultColor then
+        move.TextColor3 = Color3.fromRGB(80, 0, 0) -- #500000
+    end
+    if bar then
+        bar.Visible = true
+        bar.Size = base
+    end
+    local endTime = tick() + duration
+
+    entry.conn = RunService.RenderStepped:Connect(function()
+        local remaining = endTime - tick()
+        if remaining <= 0 then
+            if bar then
+                bar.Visible = false
+                bar.Size = base
+            end
+            if timer then
+                timer.Text = ""
+            end
+            if move and defaultColor then
+                move.TextColor3 = defaultColor
+            end
+            entry.conn:Disconnect()
+            entry.conn = nil
+            return
+        end
+        local ratio = remaining / duration
+        if timer then
+            timer.Text = string.format("%.1f", remaining)
+        end
+        if bar then
+            bar.Size = UDim2.new(
+                base.X.Scale * ratio,
+                base.X.Offset * ratio,
+                base.Y.Scale,
+                base.Y.Offset
+            )
+        end
+    end)
+end
+
+return MoveListManager


### PR DESCRIPTION
## Summary
- support new key containers with numeric prefixes
- include universal Q/F/J keys when populating the move list

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847736b1dfc832d825bca3560c3242e