### PR TITLE
Hide unused moves per style

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/ToolController.lua
+++ b/src/ReplicatedStorage/Modules/Combat/ToolController.lua
@@ -10,6 +10,7 @@ local player = Players.LocalPlayer
 -- 🔁 Config & Animation
 local ToolAnimations = require(ReplicatedStorage.Modules.Animations.Tool)
 local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 -- Internal state
 local equippedTool = nil
@@ -48,15 +49,15 @@ function ToolController.SetEquippedTool(tool)
 		activeStance = nil
 	end
 
-	-- Equip new tool
-	if tool then
+        -- Equip new tool
+        if tool then
             local styleKey = tool.Name
-		local styleConfig = ToolAnimations[styleKey]
+                local styleConfig = ToolAnimations[styleKey]
 
 		equippedTool = tool
 		equippedStyleKey = styleKey
 
-		if styleConfig and styleConfig.EquipStance then
+                if styleConfig and styleConfig.EquipStance then
 			local char = player.Character
 			local humanoid = char and char:FindFirstChildOfClass("Humanoid")
 			local animId = styleConfig.EquipStance
@@ -78,15 +79,17 @@ function ToolController.SetEquippedTool(tool)
 					warn("[ToolController] No animator found")
 				end
 			end
-		end
+                end
 
-		return
-	end
+                MoveListManager.UpdateVisibleMoves(styleKey)
+                return
+        end
 
-	-- Clear state if no valid tool
-	equippedTool = nil
-	equippedStyleKey = nil
-	print("[ToolController] Tool unequipped or invalid.")
+        -- Clear state if no valid tool
+        equippedTool = nil
+        equippedStyleKey = nil
+        print("[ToolController] Tool unequipped or invalid.")
+        MoveListManager.UpdateVisibleMoves(nil)
 end
 
 -- ✅ Combat tool validation using ToolConfig

--- a/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
+++ b/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
@@ -11,6 +11,15 @@ local playerGui = player:WaitForChild("PlayerGui")
 
 -- add default keybinds including Q, F and J which are universal
 local keys = {"C","Z","X","T","R","E","Q","F","J"}
+
+-- mapping of style -> available move keys
+local styleMoves = {
+    BasicCombat = {"R"},
+    BlackLeg = {"E", "R", "T"},
+    Rokushiki = {"E", "R", "T", "X"},
+}
+
+local universalKeys = { Q = true, F = true, J = true }
 local entries = {}
 
 local function populateEntries()
@@ -35,10 +44,17 @@ local function populateEntries()
                 local bar = container:FindFirstChild("Cooldown")
                 local timer = container:FindFirstChild("Timer")
                 local move = container:FindFirstChild("Move")
+                if bar then
+                    bar.Visible = false
+                end
+                if timer then
+                    timer.Text = ""
+                end
                 entries[key] = {
                     bar = bar,
                     timer = timer,
                     move = move,
+                    container = container,
                     base = bar and bar.Size,
                     color = move and move.TextColor3,
                 }
@@ -52,6 +68,30 @@ local function getEntry(letter)
         populateEntries()
     end
     return entries[letter]
+end
+
+local function styleAllowsKey(styleKey, key)
+    if universalKeys[key] then
+        return true
+    end
+    local list = styleMoves[styleKey]
+    if not list then return false end
+    for _, k in ipairs(list) do
+        if k == key then
+            return true
+        end
+    end
+    return false
+end
+
+function MoveListManager.UpdateVisibleMoves(styleKey)
+    populateEntries()
+    for key, entry in pairs(entries) do
+        local container = entry.container
+        if container then
+            container.Visible = styleAllowsKey(styleKey, key)
+        end
+    end
 end
 
 function MoveListManager.StartCooldown(letter, duration)

--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -28,12 +28,16 @@ local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 local HakiClient = require(ReplicatedStorage.Modules.Combat.HakiClient)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local MovesFolder = ReplicatedStorage:WaitForChild("Modules"):WaitForChild("Combat"):WaitForChild("Moves")
 local Moves = require(MovesFolder:WaitForChild("MovesConfig"))
 if DEBUG then
     print("[InputController] Loaded moves:", #Moves)
 end
+
+-- Hide style-specific moves until a tool is equipped
+MoveListManager.UpdateVisibleMoves(nil)
 
 -- 🔁 Remotes
 local Remotes = ReplicatedStorage:WaitForChild("Remotes")


### PR DESCRIPTION
## Summary
- hide cooldown UI by default
- only show move keys that the equipped style supports

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847797469ec832d8636b45264bcbb15