### PR TITLE
Fix missing Tekkai cooldown

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
@@ -17,9 +17,11 @@ local BlockClient = require(ReplicatedStorage.Modules.Combat.BlockClient)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local MovementClient = require(ReplicatedStorage.Modules.Client.MovementClient)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local KEY = Enum.KeyCode.E
 local active = false
+local lastUse = 0
 local track
 local prevWalk
 local prevJump
@@ -73,6 +75,7 @@ function Tekkai.OnInputBegan(input, gp)
     if gp then return end
     if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
     if active then return end
+    if tick() - lastUse < (TekkaiConfig.Cooldown or 0) then return end
     if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
     if BlockClient.IsBlocking() then return end
     local style = ToolController.GetEquippedStyleKey()
@@ -86,6 +89,8 @@ function Tekkai.OnInputBegan(input, gp)
         prevJump = humanoid.JumpPower
     end
     MovementClient.StopSprint()
+    lastUse = tick()
+    MoveListManager.StartCooldown(KEY.Name, TekkaiConfig.Cooldown or 0)
     TekkaiEvent:FireServer(true)
 end
 

--- a/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
@@ -54,7 +54,7 @@ local Rokushiki = {
         Startup = 0.1,
         Endlag = 0.1,
         HyperArmor = false,
-        Cooldown = 10,
+        Cooldown = 15,
     },
 }
 


### PR DESCRIPTION
## Summary
- set Tekkai cooldown to 15 seconds
- enforce cooldown client-side and display it in the move list

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68477ae21bd4832d86dd9b5db6499f5d