### PR TITLE
Preload PlayerGUI at startup

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -93,6 +93,10 @@ function PlayerGuiManager.Show()
 end
 
 function PlayerGuiManager.Hide()
+    -- Ensure the GUI exists so it can be hidden immediately when the
+    -- menu script starts. This preloads the interface upfront instead
+    -- of waiting until the player selects a style.
+    ensureGui()
     if screenGui then
         screenGui.Enabled = false
     end


### PR DESCRIPTION
## Summary
- ensure PlayerGui is cloned immediately by calling `ensureGui` in `PlayerGuiManager.Hide`
- keeps the UI hidden until the menu requests it

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `bash: rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68477b206938832d8607d5263b76004f