### PR TITLE
Fix UltBar wait hang

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -60,7 +60,10 @@ local function ensureGui()
         hakiBar = hakiFrame:WaitForChild("Middle"):WaitForChild("HakiBar")
     end
     if ultFrame then
-        ultBar = ultFrame:WaitForChild("Middle"):WaitForChild("Ultbar")
+        local middle = ultFrame:WaitForChild("Middle", 5)
+        if middle then
+            ultBar = middle:FindFirstChild("Ultbar") or middle:FindFirstChild("UltBar")
+        end
     end
 
     healthText = hpFrame:FindFirstChild("Value")


### PR DESCRIPTION
## Summary
- avoid infinite yield if the Ult bar GUI is missing

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68477dfbda84832dadf1a09947f38dac