### PR TITLE
Show cooldown for dash, block and haki actions

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -14,6 +14,7 @@ local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
 local CombatAnimations = require(ReplicatedStorage.Modules.Animations.Combat)
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 local BlockVFX = require(ReplicatedStorage.Modules.Effects.BlockVFX)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 -- Lazy reference to avoid circular require with MovementClient
 local MovementClient
 
@@ -89,6 +90,7 @@ BlockEvent.OnClientEvent:Connect(function(active)
         else
                 lastBlockEnd = tick()
                 stopBlockAnimation()
+                MoveListManager.StartCooldown(Enum.KeyCode.F.Name, blockCooldown)
         end
 end)
 

--- a/src/ReplicatedStorage/Modules/Combat/HakiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HakiClient.lua
@@ -15,8 +15,10 @@ local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local SoundConfig = require(ReplicatedStorage.Modules.Config.SoundConfig)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local KEY = Enum.KeyCode.J
+local TOGGLE_COOLDOWN = 1
 local active = {}
 local coloredParts = {}
 local originalColors = {}
@@ -121,6 +123,7 @@ function HakiClient.OnInputBegan(input, gp)
     if HakiService.GetHaki(player) <= 0 then return end
     local newState = not active[player]
     HakiEvent:FireServer(newState)
+    MoveListManager.StartCooldown(KEY.Name, TOGGLE_COOLDOWN)
 end
 
 function HakiClient.OnInputEnded() end

--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -18,6 +18,7 @@ local SoundServiceUtils = require(ReplicatedStorage.Modules.Effects.SoundService
 local DashVFX = require(ReplicatedStorage.Modules.Effects.DashVFX)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
 local ToolController = require(ReplicatedStorage.Modules.Combat.ToolController)
+local MoveListManager = require(ReplicatedStorage.Modules.UI.MoveListManager)
 
 local lastDashTime = 0
 local DASH_KEY = Enum.KeyCode.Q
@@ -180,6 +181,7 @@ function DashClient.OnInputBegan(input, gameProcessed)
         end
 
         lastDashTime = tick()
+        MoveListManager.StartCooldown(DASH_KEY.Name, DashConfig.Cooldown or 0)
         playDashAnimation(direction)
 
         local character, humanoid, _, hrp = getCharacterComponents()


### PR DESCRIPTION
## Summary
- display dash cooldown on the Q entry in the move list
- add block cooldown bar for F
- show a short cooldown after toggling haki with J

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68477f139574832da8f5d85649c43969