### PR TITLE
Restrict evasive to stunned state

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/EvasiveClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/EvasiveClient.lua
@@ -72,6 +72,8 @@ function EvasiveClient.OnInputBegan(input, gp)
     local maxVal = player:FindFirstChild("MaxEvasive")
     if not evasiveVal or not maxVal or evasiveVal.Value < maxVal.Value then return end
 
+    if not StunStatusClient.IsStunned() then return end
+
     local direction, dashVector = getDashInputAndVector()
     if not direction or not dashVector then return end
 

--- a/src/ServerScriptService/Movement/EvasiveServer.server.lua
+++ b/src/ServerScriptService/Movement/EvasiveServer.server.lua
@@ -25,6 +25,8 @@ EvasiveEvent.OnServerEvent:Connect(function(player, direction, dashVector)
         return
     end
 
+    if not StunService:IsStunned(player) then return end
+
     if not EvasiveService.Consume(player) then return end
 
     StunService.ClearStun(player)


### PR DESCRIPTION
## Summary
- only allow evasive dash while stunned on the client and server

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68478a7bf53c832da4cb2531e7665ed4