### PR TITLE
Improve performance of animation and stamina systems

### DIFF
--- a/src/ReplicatedStorage/Modules/Effects/AnimationUtils.lua
+++ b/src/ReplicatedStorage/Modules/Effects/AnimationUtils.lua
@@ -2,6 +2,9 @@
 
 local AnimationUtils = {}
 
+-- Cache created Animation objects so they can be reused across calls.
+local animationCache: {[string]: Animation} = {}
+
 function AnimationUtils.PlayAnimation(animator: Instance, animId: any, priority: Enum.AnimationPriority?)
     if not animator or not animId then
         return nil
@@ -12,8 +15,12 @@ function AnimationUtils.PlayAnimation(animator: Instance, animId: any, priority:
         id = "rbxassetid://" .. id
     end
 
-    local animation = Instance.new("Animation")
-    animation.AnimationId = id
+    local animation = animationCache[id]
+    if not animation then
+        animation = Instance.new("Animation")
+        animation.AnimationId = id
+        animationCache[id] = animation
+    end
 
     local track = animator:LoadAnimation(animation)
     track.Priority = priority or Enum.AnimationPriority.Action

--- a/src/ReplicatedStorage/Modules/Stats/StaminaService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/StaminaService.lua
@@ -46,17 +46,32 @@ function StaminaService.ResetStamina(player)
 end
 
 if RunService:IsServer() then
-    Players.PlayerAdded:Connect(setupPlayer)
-    for _, p in ipairs(Players:GetPlayers()) do
-        setupPlayer(p)
+    local activePlayers = {}
+
+    local function addPlayer(player)
+        setupPlayer(player)
+        table.insert(activePlayers, player)
     end
 
-    Players.PlayerRemoving:Connect(function(player)
+    local function removePlayer(player)
         StaminaService._regenPaused[player] = nil
-    end)
+        for i, p in ipairs(activePlayers) do
+            if p == player then
+                table.remove(activePlayers, i)
+                break
+            end
+        end
+    end
+
+    Players.PlayerAdded:Connect(addPlayer)
+    Players.PlayerRemoving:Connect(removePlayer)
+
+    for _, p in ipairs(Players:GetPlayers()) do
+        addPlayer(p)
+    end
 
     RunService.Heartbeat:Connect(function(dt)
-        for _, player in ipairs(Players:GetPlayers()) do
+        for _, player in ipairs(activePlayers) do
             if StaminaService._regenPaused[player] then
                 continue
             end


### PR DESCRIPTION
## Summary
- cache Animation objects to avoid redundant Instance creation
- maintain active player list in `StaminaService` so regen loop doesn't allocate a new players table each frame

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684793d9fb58832d9795215ff0dba109