### PR TITLE
Optimize regen and asset management

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -310,5 +310,8 @@ function PlayerGuiManager.BindEvasive(evasiveValue)
     end
 end
 
+-- Preload the GUI once on module load to avoid delays
+ensureGui()
+
 return PlayerGuiManager
 

--- a/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
+++ b/src/ServerScriptService/Misc/PlayerCollisionDisabler.server.lua
@@ -22,29 +22,33 @@ end
 PhysicsService:CollisionGroupSetCollidable(COLLISION_GROUP, COLLISION_GROUP, false)
 
 -- ✅ Recursively set collision group on all BaseParts
-local function setCollisionGroupRecursive(model)
-    for _, part in ipairs(model:GetDescendants()) do
-        if part:IsA("BasePart") and not part:IsDescendantOf(Workspace.Terrain) then
-            -- Avoid errors on locked or non-editable parts
-            pcall(function()
-                part.CollisionGroup = COLLISION_GROUP
-            end)
-        end
+local function setPartCollision(part)
+    if part:IsA("BasePart") and not part:IsDescendantOf(Workspace.Terrain) then
+        pcall(function()
+            part.CollisionGroup = COLLISION_GROUP
+        end)
     end
+end
+
+local function setupCharacter(model)
+    for _, part in ipairs(model:GetDescendants()) do
+        setPartCollision(part)
+    end
+    model.DescendantAdded:Connect(setPartCollision)
 end
 
 -- ✅ Assign when character spawns
 Players.PlayerAdded:Connect(function(player)
     player.CharacterAdded:Connect(function(character)
         character:WaitForChild("HumanoidRootPart", 5)
-        setCollisionGroupRecursive(character)
+        setupCharacter(character)
     end)
 end)
 
 -- ✅ For any characters already present (e.g., in Studio or on hot reload)
 for _, player in ipairs(Players:GetPlayers()) do
     if player.Character then
-        setCollisionGroupRecursive(player.Character)
+        setupCharacter(player.Character)
     end
 end
 

--- a/src/ServerScriptService/Movement/DashServer.server.lua
+++ b/src/ServerScriptService/Movement/DashServer.server.lua
@@ -27,6 +27,7 @@ DashEvent.OnServerEvent:Connect(function(player, direction, dashVector)
                 warn("[DashServer] Invalid dash direction:", tostring(direction))
                 return
         end
+        if not player.Character then return end
 
        if StunService:IsStunned(player) or StunService:IsAttackerLocked(player) then
                return


### PR DESCRIPTION
## Summary
- track stamina regen only for players that need it
- pool damage text GUI objects instead of creating each time
- track evasive regen per player and clean up connections
- manage collision group on new character parts only
- pre-clone PlayerGUI on module load
- consolidate stun updates into a single heartbeat
- guard DashServer against missing character

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68479de78c5c832da2bc6a95802f3f7c