### PR TITLE
Fix Tekkai immunity against guard break

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -108,6 +108,10 @@ end
 -- @param attackerRoot Instance? HumanoidRootPart of the attacking player
 function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker, attackerRoot)
        if TekkaiService.IsActive(player) then
+               if isBlockBreaker then
+                       -- Guard break moves should not deplete Tekkai HP
+                       return "Damaged"
+               end
                return TekkaiService.ApplyDamage(player, damage)
        end
 


### PR DESCRIPTION
## Summary
- make guard break moves ignore Tekkai's HP
- keep Tekkai active regardless of attack direction

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ad610074832d92a9bf64ad12b7fa