### PR TITLE
Implement ragdoll-based knockback

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/KnockbackService.lua
@@ -5,6 +5,7 @@ local Debris = game:GetService("Debris")
 
 local KnockbackConfig = require(script.Parent.KnockbackConfig)
 local Config = require(game:GetService("ReplicatedStorage").Modules.Config.Config)
+local RagdollUtils = require(script.Parent.RagdollUtils)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -38,7 +39,7 @@ local function clearForces(root)
     end
 end
 
--- Applies a knockback impulse and force to the humanoid
+-- Applies a knockback impulse while ragdolling the humanoid
 function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration, lift)
     if not humanoid then return end
     local root = humanoid.Parent and humanoid.Parent:FindFirstChild("HumanoidRootPart")
@@ -61,7 +62,8 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
 
 
 
-    humanoid.PlatformStand = false
+    -- Put the character in ragdoll mode for the duration of the knockback
+    RagdollUtils.Enable(humanoid)
     root.Anchored = false
 
     local previousOwner = nil
@@ -103,6 +105,7 @@ function KnockbackService.ApplyKnockback(humanoid, direction, distance, duration
                 print("[KnockbackService] Knockback ended for", humanoid.Parent.Name)
             end
         end
+        RagdollUtils.Disable(humanoid)
     end)
 end
 

--- a/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
+++ b/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
@@ -1,0 +1,35 @@
+--ReplicatedStorage.Modules.Combat.RagdollUtils
+
+local RagdollUtils = {}
+
+local function getHumanoidRoot(humanoid)
+    if not humanoid then return nil end
+    local char = humanoid.Parent
+    return char and char:FindFirstChild("HumanoidRootPart")
+end
+
+function RagdollUtils.Enable(humanoid)
+    if not humanoid then return end
+    humanoid:SetStateEnabled(Enum.HumanoidStateType.GettingUp, false)
+    humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+    humanoid.PlatformStand = true
+    humanoid.AutoRotate = false
+    local root = getHumanoidRoot(humanoid)
+    if root then
+        root:SetAttribute("Ragdolled", true)
+    end
+end
+
+function RagdollUtils.Disable(humanoid)
+    if not humanoid then return end
+    humanoid.PlatformStand = false
+    humanoid.AutoRotate = true
+    humanoid:SetStateEnabled(Enum.HumanoidStateType.GettingUp, true)
+    humanoid:ChangeState(Enum.HumanoidStateType.GettingUp)
+    local root = getHumanoidRoot(humanoid)
+    if root then
+        root:SetAttribute("Ragdolled", nil)
+    end
+end
+
+return RagdollUtils

--- a/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
+++ b/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
@@ -48,15 +48,16 @@ RunService.Heartbeat:Connect(function()
     end
 
 	-- Reset invalid physics states on delay
-	if tick() - lastCorrection >= CORRECTION_DELAY then
-		local state = humanoid:GetState()
-		if state == Enum.HumanoidStateType.Ragdoll
-			or state == Enum.HumanoidStateType.FallingDown
-			or state == Enum.HumanoidStateType.PlatformStanding then
-			humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
-			lastCorrection = tick()
-		end
-	end
+        if tick() - lastCorrection >= CORRECTION_DELAY then
+                local state = humanoid:GetState()
+                local knockback = hrp:GetAttribute("KnockbackActive") or hrp:GetAttribute("Ragdolled")
+                if not knockback and (state == Enum.HumanoidStateType.Ragdoll
+                        or state == Enum.HumanoidStateType.FallingDown
+                        or state == Enum.HumanoidStateType.PlatformStanding) then
+                        humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
+                        lastCorrection = tick()
+                end
+        end
 
 	-- Prevent sitting from weird physics
 	if humanoid.Sit then


### PR DESCRIPTION
## Summary
- refactor `KnockbackService.ApplyKnockback` to ragdoll the target for predictable physics
- remove the redundant ragdoll knockback APIs
- keep AntiRagdollController logic that ignores ragdoll knockback

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847aea1c7d8832dbcc55fc3b40972ab