### PR TITLE
Fix stun events when remote loads

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -17,13 +17,24 @@ if success and remotes then
 end
 
 -- Lazily fetch the remote if it wasn't available at load time
+local fetchedOnce = false
 local function fetchStunEvent()
     if StunStatusEvent then return StunStatusEvent end
     local remotesFolder = ReplicatedStorage:FindFirstChild("Remotes")
     if not remotesFolder then return nil end
     local stunFolder = remotesFolder:FindFirstChild("Stun")
     if not stunFolder then return nil end
-    StunStatusEvent = stunFolder:FindFirstChild("StunStatusRequestEvent")
+    local evt = stunFolder:FindFirstChild("StunStatusRequestEvent")
+    if not evt then return nil end
+    StunStatusEvent = evt
+    if not fetchedOnce then
+        fetchedOnce = true
+        for _, p in ipairs(Players:GetPlayers()) do
+            if sendStatus then
+                sendStatus(p)
+            end
+        end
+    end
     return StunStatusEvent
 end
 


### PR DESCRIPTION
## Summary
- ensure `StunService` sends stun status once the `StunStatusRequestEvent` remote becomes available

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68481f7723dc832db19ddf6ee1d3d918