### PR TITLE
Fix DamageText template lookup

### DIFF
--- a/src/ReplicatedStorage/Modules/Effects/DamageText.lua
+++ b/src/ReplicatedStorage/Modules/Effects/DamageText.lua
@@ -8,6 +8,10 @@ local TweenService = game:GetService("TweenService")
 local MAX_POOL_SIZE = 20
 local POOL = {}
 
+-- Forward declare so that acquire() captures the local
+-- version rather than a global lookup
+local getTemplate
+
 local function acquire()
     local gui = table.remove(POOL)
     if gui then return gui end
@@ -47,7 +51,7 @@ local function release(gui)
 end
 
 local template
-local function getTemplate()
+function getTemplate()
     if template then return template end
     local assets = ReplicatedStorage:FindFirstChild("Assets")
     if assets then


### PR DESCRIPTION
## Summary
- fix local function scoping in `DamageText` so acquire() can find `getTemplate`

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68483b3d662c832d82c520abe3482214