### PR TITLE
Remove legacy knockback implementation

### DIFF
--- a/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
@@ -13,14 +13,8 @@ CombatConfig.M1 = {
         -- pressed attack first wins the exchange and the other's hit is ignored.
         ClashWindow = 0.15,
         M1StunDuration = 0.5,
-	M1_5StunDuration = 1.5,
-
-        KnockbackDistance = 25,
-        KnockbackDuration = 0.4,
-        KnockbackLift = 3,
-        KnockbackDirection = "AttackerFacingDirection",
-
-	HitSoundDelay = 0.05,
+        M1_5StunDuration = 1.5,
+        HitSoundDelay = 0.05,
 	MissSoundDelay = 0.05,
 	DefaultM1Damage = 1,
 }

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -17,6 +17,7 @@ local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local EvasiveService = require(ReplicatedStorage.Modules.Stats.EvasiveService)
 local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local KnockbackService = require(ReplicatedStorage.Modules.Combat.KnockbackService)
+local KnockbackConfig = require(ReplicatedStorage.Modules.Combat.KnockbackConfig)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
@@ -182,27 +183,18 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 hitLanded = true
 
                 local stunDuration = isFinal and CombatConfig.M1.M1_5StunDuration or CombatConfig.M1.M1StunDuration
-                local preserve = isFinal and CombatConfig.M1.KnockbackDuration or false
+                local preserve = isFinal and (KnockbackConfig.Params[KnockbackService.DirectionType.AttackerFacingDirection].Duration) or false
                 StunService:ApplyStun(enemyHumanoid, stunDuration, isFinal, player, preserve)
 
                 -- 💥 Knockback logic
                 if isFinal then
                         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
                         if enemyRoot then
-                                local knockback = CombatConfig.M1
                                 KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-                                        DirectionType = knockback.KnockbackDirection,
+                                        DirectionType = KnockbackService.DirectionType.AttackerFacingDirection,
                                         AttackerRoot = hrp,
                                         TargetRoot = enemyRoot,
-                                        Distance = knockback.KnockbackDistance,
-                                        Duration = knockback.KnockbackDuration,
-                                        Lift = knockback.KnockbackLift,
                                 })
-
-                                local knockbackAnim = animSet and animSet.Knockback
-                                if knockbackAnim then
-                                        PlayAnimation(enemyHumanoid, knockbackAnim, "Knockback")
-                                end
                         end
                 end
 

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -203,20 +203,11 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
             if DEBUG then print("[PartyTableKick] Final hit on", enemyPlayer.Name) end
             local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
             if enemyRoot then
-                local knockback = CombatConfig.M1
                 KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-                    DirectionType = PartyTableKickConfig.KnockbackDirection or knockback.KnockbackDirection,
+                    DirectionType = PartyTableKickConfig.KnockbackDirection or KnockbackService.DirectionType.AttackerFacingDirection,
                     AttackerRoot = hrp,
                     TargetRoot = enemyRoot,
-                    Distance = knockback.KnockbackDistance,
-                    Duration = knockback.KnockbackDuration,
-                    Lift = knockback.KnockbackLift,
                 })
-
-                local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
-                if knockbackAnim then
-                    playAnimation(enemyHumanoid, knockbackAnim)
-                end
             end
         end
 

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -176,24 +176,14 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
             -- Apply knockback even though the hit was blocked
             local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
             if enemyRoot then
-                local knockback = CombatConfig.M1
                 if DEBUG then
                     print("[PowerPunch] Knockback params", PowerPunchConfig.KnockbackDirection)
                 end
                 KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-                    DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
+                    DirectionType = PowerPunchConfig.KnockbackDirection or KnockbackService.DirectionType.AttackerFacingDirection,
                     AttackerRoot = hrp,
                     TargetRoot = enemyRoot,
-                    Distance = knockback.KnockbackDistance,
-                    Duration = knockback.KnockbackDuration,
-                    Lift = knockback.KnockbackLift,
                 })
-
-                local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
-                if knockbackAnim then
-                    playAnimation(enemyHumanoid, knockbackAnim)
-                    if DEBUG then print("[PowerPunch] Knockback animation played for", enemyPlayer.Name) end
-                end
             end
 
             -- fallthrough to apply damage on block break
@@ -215,24 +205,14 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
-            local knockback = CombatConfig.M1
             if DEBUG then
                 print("[PowerPunch] Knockback params", PowerPunchConfig.KnockbackDirection)
             end
             KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-                DirectionType = PowerPunchConfig.KnockbackDirection or knockback.KnockbackDirection,
+                DirectionType = PowerPunchConfig.KnockbackDirection or KnockbackService.DirectionType.AttackerFacingDirection,
                 AttackerRoot = hrp,
                 TargetRoot = enemyRoot,
-                Distance = knockback.KnockbackDistance,
-                Duration = knockback.KnockbackDuration,
-                Lift = knockback.KnockbackLift,
             })
-
-            local knockbackAnim = AnimationData.M1.BasicCombat and AnimationData.M1.BasicCombat.Knockback
-            if knockbackAnim then
-                playAnimation(enemyHumanoid, knockbackAnim)
-                if DEBUG then print("[PowerPunch] Knockback animation played for", enemyPlayer.Name) end
-            end
         end
     end
 

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -182,20 +182,11 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
 
         local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
         if enemyRoot then
-            local knockback = CombatConfig.M1
             KnockbackService.ApplyDirectionalKnockback(enemyHumanoid, {
-                DirectionType = TempestKickConfig.KnockbackDirection or knockback.KnockbackDirection,
+                DirectionType = TempestKickConfig.KnockbackDirection or KnockbackService.DirectionType.AttackerFacingDirection,
                 AttackerRoot = hrp,
                 TargetRoot = enemyRoot,
-                Distance = knockback.KnockbackDistance,
-                Duration = knockback.KnockbackDuration,
-                Lift = knockback.KnockbackLift,
             })
-
-            local knockbackAnim = AnimationData.M1.Rokushiki and AnimationData.M1.Rokushiki.Knockback
-            if knockbackAnim then
-                playAnimation(enemyHumanoid, knockbackAnim)
-            end
         end
     end
 


### PR DESCRIPTION
## Summary
- remove outdated knockback settings from `CombatConfig`
- drop knockback animation usage in server scripts
- rely on `KnockbackService` defaults when applying knockback

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484885fe5c832dbaa934f8206a8183