### PR TITLE
Improve ragdoll limp state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ table.
 Knockback is now handled through the ragdoll system. The module
 `ReplicatedStorage.Modules.Combat.RagdollKnockback` exposes helper
 functions for applying a knockback impulse while putting the target in
-a ragdolled state.
+a ragdolled state. While ragdolled all character motors and active
+animations are disabled so the body goes completely limp until the
+knockback duration ends.
 
 ## Hit Effect Settings
 

--- a/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
+++ b/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
@@ -2,6 +2,9 @@
 
 local RagdollUtils = {}
 
+-- Track motors disabled for each humanoid so we can re-enable them later
+local DisabledMotors = setmetatable({}, {__mode = "k"})
+
 local function getHumanoidRoot(humanoid)
     if not humanoid then return nil end
     local char = humanoid.Parent
@@ -14,6 +17,29 @@ function RagdollUtils.Enable(humanoid)
     humanoid:ChangeState(Enum.HumanoidStateType.Physics)
     humanoid.PlatformStand = true
     humanoid.AutoRotate = false
+
+    -- Disable all motors so the character goes completely limp
+    if not DisabledMotors[humanoid] then
+        local char = humanoid.Parent
+        if char then
+            local motors = {}
+            for _, inst in ipairs(char:GetDescendants()) do
+                if inst:IsA("Motor6D") then
+                    table.insert(motors, inst)
+                    inst.Enabled = false
+                end
+            end
+            DisabledMotors[humanoid] = motors
+        end
+    end
+
+    -- Stop any currently playing animations
+    local animator = humanoid:FindFirstChildOfClass("Animator")
+    if animator then
+        for _, track in ipairs(animator:GetPlayingAnimationTracks()) do
+            track:Stop()
+        end
+    end
     local root = getHumanoidRoot(humanoid)
     if root then
         root:SetAttribute("Ragdolled", true)
@@ -22,6 +48,15 @@ end
 
 function RagdollUtils.Disable(humanoid)
     if not humanoid then return end
+    local motors = DisabledMotors[humanoid]
+    if motors then
+        for _, motor in ipairs(motors) do
+            if motor.Parent then
+                motor.Enabled = true
+            end
+        end
+        DisabledMotors[humanoid] = nil
+    end
     humanoid.PlatformStand = false
     humanoid.AutoRotate = true
     humanoid:SetStateEnabled(Enum.HumanoidStateType.GettingUp, true)


### PR DESCRIPTION
## Summary
- stop animation and disable motors when ragdolling characters
- document ragdoll behaviour

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684874eccd84832d9ed059a0f556416b