### PR TITLE
Fix ragdoll knockback body separation

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
+++ b/src/ReplicatedStorage/Modules/Combat/RagdollUtils.lua
@@ -41,6 +41,10 @@ local function setupConstraints(humanoid)
         if c then table.insert(created, c) end
     end
 
+    -- Keep the root part attached to the torso so knockback moves the
+    -- entire character instead of separating the body from the HP bar
+    add(ragdollJoint(char, char.HumanoidRootPart, char.LowerTorso, "Root", "BallSocket"))
+
     add(ragdollJoint(char, char.LowerTorso, char.UpperTorso, "Waist", "BallSocket", {
         {"LimitsEnabled", true},
         {"UpperAngle", 5},


### PR DESCRIPTION
## Summary
- keep `HumanoidRootPart` attached to the character during ragdoll to prevent the body from falling apart during knockback

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684887bc99ec832dba0b6b3a95059946