### PR TITLE
Apply knockback when M1 kills

### DIFF
--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -186,15 +186,14 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 StunService:ApplyStun(enemyHumanoid, stunDuration, isFinal, player, preserve)
 
                 -- 💥 Knockback logic
-                if isFinal then
-                        local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
-                        if enemyRoot then
-                                RagdollKnockback.ApplyDirectionalKnockback(enemyHumanoid, {
-                                        DirectionType = RagdollKnockback.DirectionType.AttackerFacingDirection,
-                                        AttackerRoot = hrp,
-                                        TargetRoot = enemyRoot,
-                                })
-                        end
+                local enemyRoot = enemyChar:FindFirstChild("HumanoidRootPart")
+                local enemyDied = enemyHumanoid.Health <= 0
+                if (isFinal or enemyDied) and enemyRoot then
+                        RagdollKnockback.ApplyDirectionalKnockback(enemyHumanoid, {
+                                DirectionType = RagdollKnockback.DirectionType.AttackerFacingDirection,
+                                AttackerRoot = hrp,
+                                TargetRoot = enemyRoot,
+                        })
                 end
 
 		-- ✨ VFX & Hit SFX


### PR DESCRIPTION
## Summary
- make combat knock back ragdoll if the target dies from an M1 hit

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848da91e02c832da4603e7a96a0065a