### PR TITLE
Refactor loading screen and asset paths

### DIFF
--- a/src/ReplicatedFirst/LocalScript.client.lua
+++ b/src/ReplicatedFirst/LocalScript.client.lua
@@ -1,27 +1,80 @@
---EXAMPLE CODE I FOUND ONLINE THAT WILL NOT WORK WITH MY GAME CURRENTLY
+-- This script replaces Roblox's default loading screen with a custom one and
+-- preloads important assets before the main menu runs.  It is executed from
+-- `ReplicatedFirst` so it runs as early as possible on the client.
 
 local Players = game:GetService("Players")
 local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local ContentProvider = game:GetService("ContentProvider")
+local TweenService = game:GetService("TweenService")
 
+-- Remove the default Roblox loading screen immediately
 ReplicatedFirst:RemoveDefaultLoadingScreen()
 
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
-local loadingScreen = script:WaitForChild("LoadingScreen"):Clone()
-loadingScreen.Parent = playerGui
+-- Clone the LoadingScreen UI stored under this script
+local template = script:WaitForChild("LoadingScreen")
+local loadingGui = template:Clone()
+loadingGui.Parent = playerGui
 
-local frame = loadingScreen:WaitForChild("Frame")
-local loadingText = frame:WaitForChild("TextLabel")
-local bar = frame:WaitForChild("LoadingBar"):WaitForChild("Bar")
+local background = loadingGui:WaitForChild("Background")
+local loadingText = background:WaitForChild("LoadingText")
+local assetName = background:WaitForChild("AssetNames")
+local loadBar = background
+    :WaitForChild("LoadBarBG")
+    :WaitForChild("LoadBar")
 
-local assets = game:GetChildren()
-
-for index, asset in pairs(assets) do
-	loadingText.Text = "Loading " .. asset.Name .. "..."
-	ContentProvider:PreloadAsync({asset})
-
-	local progress = index / #assets
-	bar.Size = UDim2.new(progress, 0, 1, 0)
+-- Gather all assets from ReplicatedFirst that should be preloaded
+local function gather(folder, list)
+    for _, obj in ipairs(folder:GetDescendants()) do
+        if obj:IsA("Decal")
+            or obj:IsA("Texture")
+            or obj:IsA("ImageLabel")
+            or obj:IsA("ImageButton")
+            or obj:IsA("ParticleEmitter")
+            or obj:IsA("Sound")
+            or obj:IsA("Animation") then
+            table.insert(list, obj)
+        end
+    end
 end
+
+local assetsToLoad = {}
+local assetsFolder = ReplicatedFirst:FindFirstChild("Assets")
+if assetsFolder then
+    gather(assetsFolder, assetsToLoad)
+end
+
+local vfxFolder = ReplicatedFirst:FindFirstChild("VFX")
+if vfxFolder then
+    gather(vfxFolder, assetsToLoad)
+end
+
+-- Preload each asset while updating the progress bar
+local total = #assetsToLoad
+for i, asset in ipairs(assetsToLoad) do
+    assetName.Text = asset.Name
+    ContentProvider:PreloadAsync({asset})
+    loadBar.Size = UDim2.new(i / total, 0, 1, 0)
+end
+
+-- Fade out once finished
+local tweenInfo = TweenInfo.new(0.5)
+TweenService:Create(background, tweenInfo, {BackgroundTransparency = 1}):Play()
+TweenService:Create(loadingText, tweenInfo, {TextTransparency = 1}):Play()
+TweenService:Create(assetName, tweenInfo, {TextTransparency = 1}):Play()
+TweenService:Create(loadBar, tweenInfo, {BackgroundTransparency = 1}):Play()
+local bgImage = background:FindFirstChild("BackgroundImage")
+if bgImage then
+    TweenService:Create(bgImage, tweenInfo, {ImageTransparency = 1}):Play()
+end
+
+task.wait(0.6)
+loadingGui:Destroy()
+
+-- Signal to other scripts that loading has finished
+local flag = Instance.new("BoolValue")
+flag.Name = "LoadingFinished"
+flag.Value = true
+flag.Parent = ReplicatedFirst

--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -4,6 +4,7 @@ local PlayerGuiManager = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local RunService = game:GetService("RunService")
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
@@ -34,11 +35,11 @@ local ultConnection
 local evasiveConnection
 local rainbowConnection
 
--- Clone the existing PlayerGUI from ReplicatedStorage.Assets
+-- Clone the existing PlayerGUI from ReplicatedFirst.Assets
 local function ensureGui()
     if screenGui then return end
 
-    local assets = ReplicatedStorage:WaitForChild("Assets")
+    local assets = ReplicatedFirst:WaitForChild("Assets")
     local template = assets:WaitForChild("PlayerGUI")
 
     screenGui = PlayerGui:FindFirstChild("PlayerGUI")

--- a/src/ReplicatedStorage/Modules/Combat/HakiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HakiClient.lua
@@ -4,6 +4,7 @@ local HakiClient = {}
 local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 
 local player = Players.LocalPlayer
 
@@ -22,8 +23,8 @@ local TOGGLE_COOLDOWN = 1
 local active = {}
 local coloredParts = {}
 local originalColors = {}
-local hakiTemplate = ReplicatedStorage:FindFirstChild("Assets") and
-    ReplicatedStorage.Assets:FindFirstChild("HakiEnabled")
+local hakiTemplate = ReplicatedFirst:FindFirstChild("Assets") and
+    ReplicatedFirst.Assets:FindFirstChild("HakiEnabled")
 local addedTextures = {}
 
 local function applyColor(char, style, hakiPlayer)

--- a/src/ReplicatedStorage/Modules/Effects/DamageText.lua
+++ b/src/ReplicatedStorage/Modules/Effects/DamageText.lua
@@ -3,6 +3,7 @@
 local DamageText = {}
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local TweenService = game:GetService("TweenService")
 
 local MAX_POOL_SIZE = 20
@@ -53,7 +54,7 @@ end
 local template
 function getTemplate()
     if template then return template end
-    local assets = ReplicatedStorage:FindFirstChild("Assets")
+    local assets = ReplicatedFirst:FindFirstChild("Assets")
     if assets then
         template = assets:FindFirstChild("DamageText")
     end

--- a/src/ReplicatedStorage/Modules/MenuCfgs/LoadingManager.lua
+++ b/src/ReplicatedStorage/Modules/MenuCfgs/LoadingManager.lua
@@ -2,6 +2,7 @@
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local TweenService = game:GetService("TweenService")
 local Lighting = game:GetService("Lighting")
 
@@ -19,7 +20,7 @@ local LoadingManager = {}
 function LoadingManager.BeginLoading(onComplete)
 	print("[LoadingManager] Starting loading screen")
 
-	local loadingTemplate = ReplicatedStorage.Assets:WaitForChild("LoadingScreen")
+    local loadingTemplate = ReplicatedFirst:WaitForChild("Assets"):WaitForChild("LoadingScreen")
 	local config = MenuGlobalCfg.LoadingScreen
 	local duration = config.Duration
 

--- a/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
+++ b/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
@@ -4,10 +4,11 @@ local OverheadBarService = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 
 local PlayerStats = require(ReplicatedStorage.Modules.Config.PlayerStats)
 
-local assets = ReplicatedStorage:WaitForChild("Assets")
+local assets = ReplicatedFirst:WaitForChild("Assets")
 local healthTemplate = assets:WaitForChild("HealthBar")
 local blockTemplate = assets:WaitForChild("BlockBar")
 local tekkaiTemplate = assets:FindFirstChild("TekkaiBar")

--- a/src/StarterPlayer/StarterPlayerScripts/CustomHotbar.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CustomHotbar.client.lua
@@ -12,6 +12,7 @@ local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
 local StarterGui = game:GetService("StarterGui")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 
 -- Hide the default backpack UI
 StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Backpack, false)
@@ -19,8 +20,8 @@ StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Backpack, false)
 local player = Players.LocalPlayer
 local PlayerGui = player:WaitForChild("PlayerGui")
 
--- Clone hotbar template from ReplicatedStorage.Assets
-local assets = ReplicatedStorage:WaitForChild("Assets")
+-- Clone hotbar template from ReplicatedFirst.Assets
+local assets = ReplicatedFirst:WaitForChild("Assets")
 local template = assets:WaitForChild("CustomHotbar")
 
 local hotbar = template:Clone()

--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -1,6 +1,7 @@
 -- StarterPlayerScripts > MainMenuClient
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local Players = game:GetService("Players")
 local TweenService = game:GetService("TweenService")
 local RunService = game:GetService("RunService")
@@ -13,7 +14,7 @@ local function ensureUI(name)
 	local existing = PlayerGui:FindFirstChild(name)
 	if existing then return existing end
 
-	local template = ReplicatedStorage:WaitForChild("Assets"):WaitForChild(name)
+        local template = ReplicatedFirst:WaitForChild("Assets"):WaitForChild(name)
 	local clone = template:Clone()
 	clone.Name = name
 	clone.Parent = PlayerGui
@@ -30,7 +31,6 @@ local textLabel = background:WaitForChild("Text")
 -- 🔁 Module Configs
 local MenuCfgs        = ReplicatedStorage:WaitForChild("Modules"):WaitForChild("MenuCfgs")
 local MenuLogic       = require(MenuCfgs:WaitForChild("MenuLogic"))
-local LoadingManager  = require(MenuCfgs:WaitForChild("LoadingManager"))
 local CameraManager   = require(MenuCfgs:WaitForChild("CameraManager"))
 local MenuGlobalCfg   = require(MenuCfgs:WaitForChild("MenuGlobalCfg"))
 local PlayerGuiManager = require(ReplicatedStorage.Modules.Client.PlayerGuiManager)
@@ -177,7 +177,11 @@ ReturnToMenuEvent.OnClientEvent:Connect(function()
         end)
 end)
 
--- 🚀 Begin game
-LoadingManager.BeginLoading(function()
-	initMainMenu()
-end)
+-- 🚀 Begin game once ReplicatedFirst signals that assets are loaded
+local flag = ReplicatedFirst:WaitForChild("LoadingFinished", 5)
+if flag then
+    if flag.Value == false then
+        flag.Changed:Wait()
+    end
+end
+initMainMenu()


### PR DESCRIPTION
## Summary
- implement new ReplicatedFirst loading script to preload assets
- update GUI cloning scripts to reference ReplicatedFirst
- wait for the new preload flag before showing the menu
- reference ReplicatedFirst assets in various modules

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e01a4f0c832d9721f01757868e30