### PR TITLE
Fix loading screen asset path

### DIFF
--- a/src/ReplicatedFirst/LocalScript.client.lua
+++ b/src/ReplicatedFirst/LocalScript.client.lua
@@ -13,8 +13,10 @@ ReplicatedFirst:RemoveDefaultLoadingScreen()
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
--- Clone the LoadingScreen UI stored under this script
-local template = script:WaitForChild("LoadingScreen")
+-- Clone the LoadingScreen UI stored under ReplicatedFirst.Assets
+local template = ReplicatedFirst
+    :WaitForChild("Assets")
+    :WaitForChild("LoadingScreen")
 local loadingGui = template:Clone()
 loadingGui.Parent = playerGui
 


### PR DESCRIPTION
## Summary
- update LocalScript to clone the LoadingScreen UI from `ReplicatedFirst.Assets`

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684ae7d96450832db8d9bcd0f36c43df