### PR TITLE
Fix main menu waiting for loading screen

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -180,7 +180,9 @@ ReturnToMenuEvent.OnClientEvent:Connect(function()
 end)
 
 -- 🚀 Begin game once ReplicatedFirst signals that assets are loaded
-local flag = ReplicatedFirst:WaitForChild("LoadingFinished", 5)
+-- Wait indefinitely for the LoadingFinished flag to ensure all assets are
+-- preloaded before showing the main menu
+local flag = ReplicatedFirst:WaitForChild("LoadingFinished")
 if flag then
     if flag.Value == false then
         flag.Changed:Wait()


### PR DESCRIPTION
## Summary
- fix the main menu to wait for the `LoadingFinished` flag without timing out

## Testing
- `rojo build default.project.json -o build.rbxlx` *(fails: rojo unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaeced38832d9edf0e9a4dd3d243