### PR TITLE
Fix LoadingFinished infinite yield warning

### DIFF
--- a/src/ReplicatedFirst/LocalScript.client.lua
+++ b/src/ReplicatedFirst/LocalScript.client.lua
@@ -13,6 +13,12 @@ ReplicatedFirst:RemoveDefaultLoadingScreen()
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
+-- Create the LoadingFinished flag immediately so other scripts can wait on it
+local flag = Instance.new("BoolValue")
+flag.Name = "LoadingFinished"
+flag.Value = false
+flag.Parent = ReplicatedFirst
+
 -- Clone the LoadingScreen UI stored under ReplicatedFirst.Assets
 local template = ReplicatedFirst
     :WaitForChild("Assets")
@@ -76,7 +82,4 @@ task.wait(0.6)
 loadingGui:Destroy()
 
 -- Signal to other scripts that loading has finished
-local flag = Instance.new("BoolValue")
-flag.Name = "LoadingFinished"
 flag.Value = true
-flag.Parent = ReplicatedFirst


### PR DESCRIPTION
## Summary
- ensure `LoadingFinished` BoolValue exists immediately when the loading script starts so waiting scripts don't warn
- signal completion by setting its value to `true` after assets load

## Testing
- `./rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684af259a790832d9cafeb13df5f491b