### PR TITLE
Fix map streaming for main menu

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -5,6 +5,7 @@ local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local Players = game:GetService("Players")
 local TweenService = game:GetService("TweenService")
 local RunService = game:GetService("RunService")
+local Workspace = game:GetService("Workspace")
 
 local player = Players.LocalPlayer
 local PlayerGui = player:WaitForChild("PlayerGui")
@@ -152,6 +153,10 @@ end
 local function initMainMenu()
         print("[MainMenuClient] Initializing Main Menu")
         CameraManager.ApplyMenuCamera()
+        if Workspace.StreamingEnabled then
+                local pos = CameraManager.GetMenuStartCFrame().Position
+                Workspace:RequestStreamAroundAsync(pos)
+        end
         PlayerGuiManager.Hide()
         setButtonsEnabled(true)
         MusicManager.PlayMenuMusic()


### PR DESCRIPTION
## Summary
- ensure workspace service is available for menu client
- preload map around the menu camera so players see the map in the main menu

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b38f63f60832da4dc823290a9460d