### PR TITLE
Fix streaming request call

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -154,11 +154,10 @@ local function initMainMenu()
         print("[MainMenuClient] Initializing Main Menu")
     CameraManager.ApplyMenuCamera()
     if Workspace.StreamingEnabled then
-        local requestStream = Workspace.RequestStreamAroundAsync
-        if typeof(requestStream) == "function" then
-            local pos = CameraManager.GetMenuStartCFrame().Position
-            requestStream(Workspace, pos)
-        end
+        local pos = CameraManager.GetMenuStartCFrame().Position
+        pcall(function()
+            Workspace:RequestStreamAroundAsync(pos)
+        end)
     end
         PlayerGuiManager.Hide()
         setButtonsEnabled(true)


### PR DESCRIPTION
## Summary
- handle missing `RequestStreamAroundAsync` gracefully by wrapping call in `pcall`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b9805a4832d958f036218c269d9