### PR TITLE
Fix lobby spawn

### DIFF
--- a/src/ServerScriptService/Misc/ServerMenuVisibility.server.lua
+++ b/src/ServerScriptService/Misc/ServerMenuVisibility.server.lua
@@ -52,12 +52,15 @@ end
 local menuConns = {}
 
 PlayerEnteredMenu.OnServerEvent:Connect(function(player)
+        if not player.Character then
+                player:LoadCharacter()
+        end
         if player.Character then
                 placeCharacterInLobby(player.Character)
         end
-	if menuConns[player] then
-		menuConns[player]:Disconnect()
-	end
+        if menuConns[player] then
+                menuConns[player]:Disconnect()
+        end
         menuConns[player] = player.CharacterAdded:Connect(function(char)
                 placeCharacterInLobby(char)
         end)


### PR DESCRIPTION
## Summary
- ensure players get a character loaded when entering the menu so they spawn in the lobby

## Testing
- `aftman install` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f6048b8832db350666becd47059