### PR TITLE
Add server day-night cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The hit highlight shown when a character is damaged is configured in
 `ReplicatedStorage/Modules/Config/HitEffectConfig.lua`. These values are loaded
 through the main `Config` module and accessible as `Config.HitEffect`.
 
+## Day/Night Cycle
+
+The server script `ServerScriptService/Misc/DayNightCycle.server.lua` rotates
+`Lighting.ClockTime` to simulate day and night. All servers use the current UTC
+time so their cycles stay in sync. The full cycle duration is controlled by
+`Config.GameSettings.DayNightCycleMinutes`, which defaults to 15 minutes but can
+be adjusted as needed.
+
 
 ## Development Setup
 

--- a/src/ReplicatedStorage/Modules/Config/Config.lua
+++ b/src/ReplicatedStorage/Modules/Config/Config.lua
@@ -15,6 +15,7 @@ Config.GameSettings = {
         JumpCooldown = 1.25,
         DebugEnabled = true, -- Global debug toggle
         AttackerLockoutDuration = 0, -- Remove extra delay after hits
+        DayNightCycleMinutes = 15, -- Length of a full day/night cycle
 }
 
 Config.HitEffect = HitEffectConfig

--- a/src/ServerScriptService/Misc/DayNightCycle.server.lua
+++ b/src/ServerScriptService/Misc/DayNightCycle.server.lua
@@ -1,0 +1,21 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Lighting = game:GetService("Lighting")
+local RunService = game:GetService("RunService")
+
+local Config = require(ReplicatedStorage.Modules.Config.Config)
+
+local minutes = Config.GameSettings.DayNightCycleMinutes or 15
+local cycleSeconds = minutes * 60
+
+local function computeClockTime()
+    local utc = os.date("!*t")
+    local secondsToday = utc.hour * 3600 + utc.min * 60 + utc.sec
+    local cyclePos = secondsToday % cycleSeconds
+    return (cyclePos / cycleSeconds) * 24
+end
+
+RunService.Heartbeat:Connect(function()
+    Lighting.ClockTime = computeClockTime()
+end)
+
+print("[DayNightCycle] Initialized (", minutes, "min cycle)")


### PR DESCRIPTION
## Summary
- implement a simple day/night cycle driven by a config value
- document the new configuration
- sync the cycle across servers using real UTC time

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c445b9dd8832d88abea25019170b7