### PR TITLE
Add persistent stats tracking

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -2,6 +2,8 @@
 
 local BlockService = {}
 
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
+
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
 
@@ -134,6 +136,7 @@ function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker, attackerR
                -- Reflect to attacker happens in CombatService
                -- Do not stop blocking on a perfect block so the player remains
                -- in a blocking state
+               PersistentStats.RecordBlockedDamage(player, 0, true)
                return "Perfect"
        end
 
@@ -144,6 +147,7 @@ function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker, attackerR
 
 	-- 🩸 Block damage
         hp -= damage
+        PersistentStats.RecordBlockedDamage(player, damage, false)
         if hp <= 0 then
                 BlockService.StopBlocking(player)
                 return "Broken"

--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -1,0 +1,137 @@
+--ReplicatedStorage.Modules.Stats.PersistentStatsService
+
+local PersistentStatsService = {}
+
+local Players = game:GetService("Players")
+local DataStoreService = game:GetService("DataStoreService")
+local RunService = game:GetService("RunService")
+
+local DEFAULT_DATA = {
+    Kills = 0,
+    Deaths = 0,
+    DamageDealt = 0,
+    DamageTaken = 0,
+    BlockedDamage = 0,
+    PerfectBlocks = 0,
+    UltimatesUsed = 0,
+    Currency = 0,
+    Level = 1,
+}
+
+local dataStore = DataStoreService:GetDataStore("PersistentPlayerStats")
+local cache = {} -- [player] = data table
+local lastAttacker = {} -- [Humanoid] = player
+
+local function loadPlayer(player)
+    local data
+    local ok, err = pcall(function()
+        data = dataStore:GetAsync(player.UserId)
+    end)
+    if not ok or typeof(data) ~= "table" then
+        data = table.clone(DEFAULT_DATA)
+    else
+        for k, v in pairs(DEFAULT_DATA) do
+            if data[k] == nil then
+                data[k] = v
+            end
+        end
+    end
+    cache[player] = data
+end
+
+local function savePlayer(player)
+    local data = cache[player]
+    if not data then return end
+    pcall(function()
+        dataStore:SetAsync(player.UserId, data)
+    end)
+end
+
+local function onHumanoidDied(hum)
+    local victim = Players:GetPlayerFromCharacter(hum.Parent)
+    if victim then
+        PersistentStatsService.AddStat(victim, "Deaths", 1)
+    end
+    local killer = lastAttacker[hum]
+    if killer then
+        PersistentStatsService.AddStat(killer, "Kills", 1)
+    end
+    lastAttacker[hum] = nil
+end
+
+local function trackCharacter(player, char)
+    local hum = char:FindFirstChildOfClass("Humanoid") or char:WaitForChild("Humanoid", 5)
+    if hum then
+        hum.Died:Connect(function()
+            onHumanoidDied(hum)
+        end)
+    end
+end
+
+if RunService:IsServer() then
+    Players.PlayerAdded:Connect(function(player)
+        loadPlayer(player)
+        player.CharacterAdded:Connect(function(char)
+            trackCharacter(player, char)
+        end)
+        if player.Character then
+            trackCharacter(player, player.Character)
+        end
+    end)
+
+    for _, p in ipairs(Players:GetPlayers()) do
+        loadPlayer(p)
+        if p.Character then
+            trackCharacter(p, p.Character)
+        end
+    end
+
+    Players.PlayerRemoving:Connect(function(player)
+        savePlayer(player)
+        cache[player] = nil
+    end)
+end
+
+function PersistentStatsService.Get(player)
+    return cache[player]
+end
+
+function PersistentStatsService.AddStat(player, key, amount)
+    if not RunService:IsServer() then return end
+    local data = cache[player]
+    if data then
+        data[key] = (data[key] or 0) + (amount or 0)
+    end
+end
+
+function PersistentStatsService.RecordHit(attacker, targetHumanoid, damage)
+    if not RunService:IsServer() then return end
+    if attacker and damage then
+        PersistentStatsService.AddStat(attacker, "DamageDealt", damage)
+    end
+    local defender = Players:GetPlayerFromCharacter(targetHumanoid.Parent)
+    if defender and damage then
+        PersistentStatsService.AddStat(defender, "DamageTaken", damage)
+    end
+    if targetHumanoid then
+        lastAttacker[targetHumanoid] = attacker
+    end
+end
+
+function PersistentStatsService.RecordBlockedDamage(player, amount, perfect)
+    if not RunService:IsServer() then return end
+    if perfect then
+        PersistentStatsService.AddStat(player, "PerfectBlocks", 1)
+    end
+    if amount and amount > 0 then
+        PersistentStatsService.AddStat(player, "BlockedDamage", amount)
+    end
+end
+
+function PersistentStatsService.RecordUltimateUse(player)
+    if not RunService:IsServer() then return end
+    PersistentStatsService.AddStat(player, "UltimatesUsed", 1)
+end
+
+return PersistentStatsService
+

--- a/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
+++ b/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
@@ -20,6 +20,7 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -86,6 +87,7 @@ StartEvent.OnServerEvent:Connect(function(player)
         if DEBUG then print("[AntiMannerKickCourse] Ult not full") end
         return
     end
+    PersistentStats.RecordUltimateUse(player)
     if not StaminaService.Consume(player, MoveConfig.StaminaCost or 0) then
         if DEBUG then print("[AntiMannerKickCourse] Not enough stamina") end
         return
@@ -171,6 +173,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[AntiMannerKickCourse] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -20,6 +20,7 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local AnimationUtils = require(ReplicatedStorage.Modules.Effects.AnimationUtils)
 
 -- 🔁 Remotes
@@ -178,6 +179,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
 		-- ✅ Deal damage and apply stun
                 enemyHumanoid:TakeDamage(damage)
                 DamageText.Show(enemyHumanoid, damage)
+                PersistentStats.RecordHit(player, enemyHumanoid, damage)
                 UltService.RegisterHit(player, enemyHumanoid, UltConfig.M1s)
                 hitLanded = true
 

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -21,6 +21,7 @@ local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -199,6 +200,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[Concasse] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -20,6 +20,7 @@ local EvasiveService = require(ReplicatedStorage.Modules.Stats.EvasiveService)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
 local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
 local MoveSoundConfig = require(ReplicatedStorage.Modules.Config.MoveSoundConfig)
@@ -193,6 +194,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         hitLanded = true
         if DEBUG then print("[PartyTableKick] Hit", enemyPlayer.Name) end

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -20,6 +20,7 @@ local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -177,6 +178,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[PowerKick] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -24,6 +24,7 @@ local Config = require(ReplicatedStorage.Modules.Config.Config)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -195,6 +196,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[PowerPunch] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true

--- a/src/ServerScriptService/Combat/Rokugan.server.lua
+++ b/src/ServerScriptService/Combat/Rokugan.server.lua
@@ -20,6 +20,7 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -87,6 +88,7 @@ StartEvent.OnServerEvent:Connect(function(player, destPos)
         if DEBUG then print("[Rokugan] Ult not full") end
         return
     end
+    PersistentStats.RecordUltimateUse(player)
     if not StaminaService.Consume(player, MoveConfig.StaminaCost or 0) then
         if DEBUG then print("[Rokugan] Not enough stamina") end
         return
@@ -169,6 +171,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/Shigan.server.lua
+++ b/src/ServerScriptService/Combat/Shigan.server.lua
@@ -20,6 +20,7 @@ local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local EvasiveService = require(ReplicatedStorage.Modules.Stats.EvasiveService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -155,6 +156,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[Shigan] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -24,6 +24,7 @@ local Config = require(ReplicatedStorage.Modules.Config.Config)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
 
@@ -173,6 +174,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         end
         enemyHumanoid:TakeDamage(dmg)
         DamageText.Show(enemyHumanoid, dmg)
+        PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
         if DEBUG then print("[TempestKick] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true


### PR DESCRIPTION
## Summary
- add `PersistentStatsService` module to save & load long-term player stats
- track blocked damage and perfect blocks in `BlockService`
- update combat scripts to record damage and ultimate usage

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c52f08a14832d8b20709550c899fb