### PR TITLE
Implement XP-based leveling system

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ time so their cycles stay in sync. The full cycle duration is controlled by
 `Config.GameSettings.DayNightCycleMinutes`, which defaults to 15 minutes but can
 be adjusted as needed.
 
+## Leveling System
+
+Player levels are stored persistently and increase when enough experience is
+earned. Landing basic attacks or moves grants 1 XP, ultimate abilities grant
+25 XP and defeating another player awards 200 XP. The XP cost for each new
+level scales smoothly according to `XPConfig.XPForLevel`. Reaching level 2
+requires 500 XP with costs growing exponentially from there, so very high
+levels take considerable time but remain achievable.
+
 
 ## Development Setup
 

--- a/src/ReplicatedStorage/Modules/Config/XPConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/XPConfig.lua
@@ -1,0 +1,15 @@
+local XPConfig = {}
+
+XPConfig.LevelBase = 500
+XPConfig.LevelGrowth = 1.07
+
+XPConfig.M1 = 1
+XPConfig.Move = 1
+XPConfig.Ult = 25
+XPConfig.Kill = 200
+
+function XPConfig.XPForLevel(level)
+    return math.floor(XPConfig.LevelBase * (XPConfig.LevelGrowth ^ (level - 1)) * level)
+end
+
+return XPConfig

--- a/src/ReplicatedStorage/Modules/Stats/ExperienceService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/ExperienceService.lua
@@ -1,0 +1,88 @@
+--ReplicatedStorage.Modules.Stats.ExperienceService
+
+local ExperienceService = {}
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
+local PersistentStats = require(script.Parent.PersistentStatsService)
+
+local function setupPlayer(player)
+    local levelVal = player:FindFirstChild("Level")
+    if not levelVal then
+        levelVal = Instance.new("IntValue")
+        levelVal.Name = "Level"
+        levelVal.Parent = player
+    end
+
+    local xpVal = player:FindFirstChild("XP")
+    if not xpVal then
+        xpVal = Instance.new("IntValue")
+        xpVal.Name = "XP"
+        xpVal.Parent = player
+    end
+
+    local data = PersistentStats.Get(player)
+    if data then
+        levelVal.Value = data.Level or 1
+        xpVal.Value = data.XP or 0
+    else
+        levelVal.Value = 1
+        xpVal.Value = 0
+    end
+end
+
+if RunService:IsServer() then
+    Players.PlayerAdded:Connect(function(player)
+        setupPlayer(player)
+    end)
+    for _, p in ipairs(Players:GetPlayers()) do
+        setupPlayer(p)
+    end
+end
+
+function ExperienceService.XPForLevel(level)
+    return XPConfig.XPForLevel(level)
+end
+
+function ExperienceService.GetXP(player)
+    local val = player and player:FindFirstChild("XP")
+    return val and val.Value or 0
+end
+
+function ExperienceService.GetLevel(player)
+    local val = player and player:FindFirstChild("Level")
+    return val and val.Value or 1
+end
+
+function ExperienceService.AddXP(player, amount)
+    if not RunService:IsServer() then return end
+    if not player or not amount or amount <= 0 then return end
+    local data = PersistentStats.Get(player)
+    if not data then return end
+    data.XP = (data.XP or 0) + amount
+    local level = data.Level or 1
+    local xpNeeded = ExperienceService.XPForLevel(level)
+    while data.XP >= xpNeeded do
+        data.XP -= xpNeeded
+        level += 1
+        xpNeeded = ExperienceService.XPForLevel(level)
+    end
+    data.Level = level
+
+    local xpVal = player:FindFirstChild("XP")
+    if xpVal then xpVal.Value = data.XP end
+    local levelVal = player:FindFirstChild("Level")
+    if levelVal then levelVal.Value = level end
+end
+
+function ExperienceService.RegisterHit(attacker, targetHumanoid, amount)
+    if not RunService:IsServer() then return end
+    if attacker and targetHumanoid then
+        ExperienceService.AddXP(attacker, amount or 0)
+    end
+end
+
+return ExperienceService

--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -5,6 +5,7 @@ local PersistentStatsService = {}
 local Players = game:GetService("Players")
 local DataStoreService = game:GetService("DataStoreService")
 local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local DEFAULT_DATA = {
     Kills = 0,
@@ -17,6 +18,7 @@ local DEFAULT_DATA = {
     -- Total playtime in hours across all sessions
     PlaytimeHours = 0,
     Currency = 0,
+    XP = 0,
     Level = 1,
 }
 
@@ -58,6 +60,9 @@ local function onHumanoidDied(hum)
     local killer = lastAttacker[hum]
     if killer then
         PersistentStatsService.AddStat(killer, "Kills", 1)
+        local ExperienceService = require(script.Parent.ExperienceService)
+        local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
+        ExperienceService.AddXP(killer, XPConfig.Kill)
     end
     lastAttacker[hum] = nil
 end

--- a/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
+++ b/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
@@ -20,6 +20,8 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
@@ -175,6 +177,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Ult)
         if DEBUG then print("[AntiMannerKickCourse] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -20,6 +20,8 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local AnimationUtils = require(ReplicatedStorage.Modules.Effects.AnimationUtils)
 
@@ -181,6 +183,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 DamageText.Show(enemyHumanoid, damage)
                 PersistentStats.RecordHit(player, enemyHumanoid, damage)
                 UltService.RegisterHit(player, enemyHumanoid, UltConfig.M1s)
+                XPService.RegisterHit(player, enemyHumanoid, XPConfig.M1)
                 hitLanded = true
 
                 local stunDuration = isFinal and CombatConfig.M1.M1_5StunDuration or CombatConfig.M1.M1StunDuration

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -21,6 +21,8 @@ local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
@@ -202,6 +204,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         if DEBUG then print("[Concasse] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -20,6 +20,8 @@ local EvasiveService = require(ReplicatedStorage.Modules.Stats.EvasiveService)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local HighlightEffect = require(ReplicatedStorage.Modules.Combat.HighlightEffect)
 local DamageText = require(ReplicatedStorage.Modules.Effects.DamageText)
@@ -196,6 +198,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         hitLanded = true
         if DEBUG then print("[PartyTableKick] Hit", enemyPlayer.Name) end
         local stunDur = isFinal and CombatConfig.M1.M1_5StunDuration or cfg.StunDuration

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -20,6 +20,8 @@ local SoundUtils = require(ReplicatedStorage.Modules.Effects.SoundServiceUtils)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
@@ -180,6 +182,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         if DEBUG then print("[PowerKick] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -24,6 +24,8 @@ local Config = require(ReplicatedStorage.Modules.Config.Config)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -198,6 +200,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         if DEBUG then print("[PowerPunch] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/Rokugan.server.lua
+++ b/src/ServerScriptService/Combat/Rokugan.server.lua
@@ -20,6 +20,8 @@ local RagdollKnockback = require(ReplicatedStorage.Modules.Combat.RagdollKnockba
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
@@ -173,6 +175,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Ult)
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)
 

--- a/src/ServerScriptService/Combat/Shigan.server.lua
+++ b/src/ServerScriptService/Combat/Shigan.server.lua
@@ -20,6 +20,8 @@ local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local EvasiveService = require(ReplicatedStorage.Modules.Stats.EvasiveService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -158,6 +160,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         if DEBUG then print("[Shigan] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -24,6 +24,8 @@ local Config = require(ReplicatedStorage.Modules.Config.Config)
 local HakiService = require(ReplicatedStorage.Modules.Stats.HakiService)
 local UltService = require(ReplicatedStorage.Modules.Stats.UltService)
 local UltConfig = require(ReplicatedStorage.Modules.Config.UltConfig)
+local XPService = require(ReplicatedStorage.Modules.Stats.ExperienceService)
+local XPConfig = require(ReplicatedStorage.Modules.Config.XPConfig)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 
 local DEBUG = Config.GameSettings.DebugEnabled
@@ -176,6 +178,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         DamageText.Show(enemyHumanoid, dmg)
         PersistentStats.RecordHit(player, enemyHumanoid, dmg)
         UltService.RegisterHit(player, enemyHumanoid, UltConfig.Moves)
+        XPService.RegisterHit(player, enemyHumanoid, XPConfig.Move)
         if DEBUG then print("[TempestKick] Hit", enemyPlayer.Name, "for", dmg) end
         hitLanded = true
         HighlightEffect.ApplyHitHighlight(enemyHumanoid.Parent)


### PR DESCRIPTION
## Summary
- add new `XPConfig` for XP values and scaling function
- track XP and Level for each player via `ExperienceService`
- persist XP in `PersistentStatsService` and award XP for kills
- grant XP when landing hits across combat scripts
- document the new leveling system in README

## Testing
- `apt-get update`
- `apt-get install -y rojo` *(fails: package not found)*
- `curl -L -o rojo.tar.gz https://github.com/rojo-rbx/rojo/releases/latest/download/rojo-x86_64-unknown-linux-gnu.tar.gz` *(fails: file not gzip)*
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5e66a704832d99f19e6ef94df1a6