### PR TITLE
Fix datastore usage on client

### DIFF
--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -22,7 +22,10 @@ local DEFAULT_DATA = {
     Level = 1,
 }
 
-local dataStore = DataStoreService:GetDataStore("PersistentPlayerStats")
+local dataStore
+if RunService:IsServer() then
+    dataStore = DataStoreService:GetDataStore("PersistentPlayerStats")
+end
 local cache = {} -- [player] = data table
 local lastAttacker = {} -- [Humanoid] = player
 local joinTimes = {} -- [player] = tick() when they joined


### PR DESCRIPTION
## Summary
- prevent clients from initializing DataStoreService in `PersistentStatsService`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c775248ac832d9e9c8177f9180b56