### PR TITLE
Fix XP bar label

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
+++ b/src/ReplicatedStorage/Modules/Client/PlayerGuiManager.lua
@@ -263,7 +263,7 @@ function PlayerGuiManager.BindXP(xpValue)
         )
 
         if xpText then
-            xpText.Text = string.format("%d / %d", xpValue.Value, needed - xpValue.Value)
+            xpText.Text = string.format("%d / %d", xpValue.Value, needed)
         end
     end
 


### PR DESCRIPTION
## Summary
- keep XP label's total consistent while XP fills up

## Testing
- `rojo build default.project.json -o build.rbxl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7f624ee4832d9910ed8ff48e4f39