### PR TITLE
Fix duplicate kill credit

### DIFF
--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -28,6 +28,7 @@ if RunService:IsServer() then
 end
 local cache = {} -- [player] = data table
 local lastAttacker = {} -- [Humanoid] = player
+local processedDeaths = setmetatable({}, {__mode = "k"}) -- [Humanoid] = true
 local joinTimes = {} -- [player] = tick() when they joined
 
 local function loadPlayer(player)
@@ -56,6 +57,8 @@ local function savePlayer(player)
 end
 
 local function onHumanoidDied(hum)
+    if processedDeaths[hum] then return end
+    processedDeaths[hum] = true
     local victim = Players:GetPlayerFromCharacter(hum.Parent)
     if victim then
         PersistentStatsService.AddStat(victim, "Deaths", 1)

--- a/src/ReplicatedStorage/Modules/Stats/UltService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/UltService.lua
@@ -11,6 +11,7 @@ local UltService = {}
 UltService.DEFAULT_MAX = UltConfig.UltBarMax
 
 local lastAttacker = {}
+local processedDeaths = setmetatable({}, {__mode = "k"})
 
 local function setupPlayer(player)
     local max = player:FindFirstChild("MaxUlt")
@@ -32,6 +33,8 @@ end
 
 local function trackHumanoid(hum)
     hum.Died:Connect(function()
+        if processedDeaths[hum] then return end
+        processedDeaths[hum] = true
         local killer = lastAttacker[hum]
         if killer then
             UltService.AddUlt(killer, UltConfig.Kills)


### PR DESCRIPTION
## Summary
- prevent multiple Died events from crediting kills more than once

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca13c2844832da0cf966fcacd3e99