### PR TITLE
Fix XP bar initialization

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -120,13 +120,13 @@ local function spawnAndFollow(toolName)
         if ultVal then
                 PlayerGuiManager.BindUlt(ultVal)
         end
-        local xpVal = player:FindFirstChild("XP") or player:WaitForChild("XP", 5)
-        if xpVal then
-                PlayerGuiManager.BindXP(xpVal)
-        end
         local levelVal = player:FindFirstChild("Level") or player:WaitForChild("Level", 5)
         if levelVal then
                 PlayerGuiManager.BindLevel(levelVal)
+        end
+        local xpVal = player:FindFirstChild("XP") or player:WaitForChild("XP", 5)
+        if xpVal then
+                PlayerGuiManager.BindXP(xpVal)
         end
         local evasiveVal = player:FindFirstChild("Evasive") or player:WaitForChild("Evasive", 5)
         if evasiveVal then


### PR DESCRIPTION
## Summary
- ensure Level value is bound before XP to properly display progress bar

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684ca2d11cb0832db8941d7eb4b7d640