### PR TITLE
Fix XP and level text not updating

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -120,14 +120,13 @@ local function spawnAndFollow(toolName)
         if ultVal then
                 PlayerGuiManager.BindUlt(ultVal)
         end
-        local levelVal = player:FindFirstChild("Level") or player:WaitForChild("Level", 5)
-        if levelVal then
-                PlayerGuiManager.BindLevel(levelVal)
-        end
-        local xpVal = player:FindFirstChild("XP") or player:WaitForChild("XP", 5)
-        if xpVal then
-                PlayerGuiManager.BindXP(xpVal)
-        end
+        -- Wait indefinitely for XP/Level values to ensure they exist even if
+        -- data loading from the server is delayed
+        local levelVal = player:WaitForChild("Level")
+        PlayerGuiManager.BindLevel(levelVal)
+
+        local xpVal = player:WaitForChild("XP")
+        PlayerGuiManager.BindXP(xpVal)
         local evasiveVal = player:FindFirstChild("Evasive") or player:WaitForChild("Evasive", 5)
         if evasiveVal then
                 PlayerGuiManager.BindEvasive(evasiveVal)


### PR DESCRIPTION
## Summary
- load XP and level values without a timeout so GUI binds correctly

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e054eeda8832d84cfa76ccf93ec08