### PR TITLE
Prevent hitting dead players

### DIFF
--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -128,6 +128,7 @@ end
 
 function PersistentStatsService.RecordHit(attacker, targetHumanoid, damage)
     if not RunService:IsServer() then return end
+    if targetHumanoid and targetHumanoid.Health <= 0 then return end
     if attacker and damage then
         PersistentStatsService.AddStat(attacker, "DamageDealt", damage)
     end

--- a/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
+++ b/src/ServerScriptService/Combat/AntiMannerKickCourse.server.lua
@@ -124,7 +124,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[AntiMannerKickCourse] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -142,9 +142,9 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
 	for _, enemyPlayer in ipairs(targetPlayers) do
 		if not enemyPlayer or not enemyPlayer.Character then continue end
 
-		local enemyChar = enemyPlayer.Character
+                local enemyChar = enemyPlayer.Character
                 local enemyHumanoid = enemyChar:FindFirstChildOfClass("Humanoid")
-                if not enemyHumanoid then continue end
+                if not enemyHumanoid or enemyHumanoid.Health <= 0 then continue end
                 if EvasiveService and EvasiveService.IsActive(enemyPlayer) then
                         continue
                 end

--- a/src/ServerScriptService/Combat/Concasse.server.lua
+++ b/src/ServerScriptService/Combat/Concasse.server.lua
@@ -158,7 +158,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[Concasse] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -139,7 +139,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, isFinal)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[PartyTableKick] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/PowerKick.server.lua
+++ b/src/ServerScriptService/Combat/PowerKick.server.lua
@@ -119,7 +119,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[PowerKick] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/PowerPunch.server.lua
+++ b/src/ServerScriptService/Combat/PowerPunch.server.lua
@@ -128,7 +128,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[PowerPunch] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/Rokugan.server.lua
+++ b/src/ServerScriptService/Combat/Rokugan.server.lua
@@ -128,7 +128,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
         local enemyRoot = enemyChar and enemyChar:FindFirstChild("HumanoidRootPart")
-        if not enemyHumanoid or not enemyRoot then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 or not enemyRoot then
             if DEBUG then print("[Rokugan] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/Shigan.server.lua
+++ b/src/ServerScriptService/Combat/Shigan.server.lua
@@ -114,7 +114,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[Shigan] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Combat/TempestKick.server.lua
+++ b/src/ServerScriptService/Combat/TempestKick.server.lua
@@ -133,7 +133,7 @@ HitEvent.OnServerEvent:Connect(function(player, targets, dir)
     for _, enemyPlayer in ipairs(targets) do
         local enemyChar = enemyPlayer.Character
         local enemyHumanoid = enemyChar and enemyChar:FindFirstChildOfClass("Humanoid")
-        if not enemyHumanoid then
+        if not enemyHumanoid or enemyHumanoid.Health <= 0 then
             if DEBUG then print("[TempestKick] Target has no humanoid") end
             continue
         end

--- a/src/ServerScriptService/Spawner/DeathHandler.server.lua
+++ b/src/ServerScriptService/Spawner/DeathHandler.server.lua
@@ -2,6 +2,7 @@
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Debris = game:GetService("Debris")
 
 -- ✅ Correct remote path
 local Remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -14,13 +15,14 @@ local hasSpawned = require(script.Parent:WaitForChild("SpawnRegistry"))
 Players.PlayerAdded:Connect(function(player)
 	player.CharacterAdded:Connect(function(char)
 		local humanoid = char:WaitForChild("Humanoid", 5)
-		if humanoid then
-			humanoid.Died:Connect(function()
-				print("[DeathHandler] Player died:", player.Name)
-				hasSpawned[player] = nil
-				ReturnToMenuEvent:FireClient(player)
-			end)
-		end
+                if humanoid then
+                        humanoid.Died:Connect(function()
+                                print("[DeathHandler] Player died:", player.Name)
+                                hasSpawned[player] = nil
+                                ReturnToMenuEvent:FireClient(player)
+                                Debris:AddItem(char, math.random(5, 10))
+                        end)
+                end
 	end)
 end)
 


### PR DESCRIPTION
## Summary
- prevent hit registration on dead players
- destroy corpses after a short delay
- skip stat tracking for hits on dead humanoids

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_684e068724fc832da9890ddc314f5028