### PR TITLE
Fix XP/Level sync on join

### DIFF
--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -46,6 +46,26 @@ local function loadPlayer(player)
         end
     end
     cache[player] = data
+
+    -- Update the player's replicated XP/Level values now that persistent
+    -- data has been loaded. ExperienceService may have already created
+    -- these IntValues while default data was still in place, so ensure
+    -- they reflect the values we just loaded.
+    local levelVal = player:FindFirstChild("Level")
+    if not levelVal then
+        levelVal = Instance.new("IntValue")
+        levelVal.Name = "Level"
+        levelVal.Parent = player
+    end
+    levelVal.Value = data.Level or 1
+
+    local xpVal = player:FindFirstChild("XP")
+    if not xpVal then
+        xpVal = Instance.new("IntValue")
+        xpVal.Name = "XP"
+        xpVal.Parent = player
+    end
+    xpVal.Value = data.XP or 0
 end
 
 local function savePlayer(player)


### PR DESCRIPTION
## Summary
- ensure XP and Level values update once persistent data loads

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0b7c95e4832dbdce123052f14ba0