### PR TITLE
Enhance stun feedback

### DIFF
--- a/src/ReplicatedStorage/Modules/Client/MovementClient.lua
+++ b/src/ReplicatedStorage/Modules/Client/MovementClient.lua
@@ -33,8 +33,11 @@ local isLocked = false
 
 -- Sync stun/lock status from server
 StunStatusEvent.OnClientEvent:Connect(function(data)
-	isStunned = data.Stunned
-	isLocked = data.AttackerLock
+        isStunned = data.Stunned
+        isLocked = data.AttackerLock
+        if typeof(data.LockRemaining) == "number" and data.LockRemaining > 0 then
+                StunStatusClient.LockFor(data.LockRemaining)
+        end
 end)
 
 local function beginSprint()

--- a/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
@@ -32,11 +32,14 @@ function StunStatusClient:CanAct()
 end
 
 -- Allow updates from remote event (used in MovementClient, etc.)
-function StunStatusClient.SetStatus(stunned, locked)
+function StunStatusClient.SetStatus(stunned, locked, lockRemaining)
         isStunned = stunned
         serverLocked = locked
+        if typeof(lockRemaining) == "number" and lockRemaining > 0 then
+            localLockUntil = math.max(localLockUntil, tick() + lockRemaining)
+        end
         if DEBUG then
-            print("[StunStatusClient] Status update", stunned, locked)
+            print("[StunStatusClient] Status update", stunned, locked, lockRemaining)
         end
 end
 

--- a/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/CombatConfig.lua
@@ -15,8 +15,10 @@ CombatConfig.M1 = {
         M1StunDuration = 0.5,
         M1_5StunDuration = 1.5,
         HitSoundDelay = 0.05,
-	MissSoundDelay = 0.05,
-	DefaultM1Damage = 1,
+        MissSoundDelay = 0.05,
+        DefaultM1Damage = 1,
+        -- Maximum distance the server will allow for a confirmed hit
+        ServerHitRange = 12,
 }
 
 CombatConfig.Blocking = {

--- a/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/InputController.client.lua
@@ -48,7 +48,7 @@ local StunStatusEvent = Stun:WaitForChild("StunStatusRequestEvent")
 
 -- Update stun status using the provided helper instead of overwriting the API
 StunStatusEvent.OnClientEvent:Connect(function(data)
-        StunStatusClient.SetStatus(data.Stunned, data.AttackerLock)
+        StunStatusClient.SetStatus(data.Stunned, data.AttackerLock, data.LockRemaining)
         if data.Stunned then
                 DashClient.CancelDash()
         end


### PR DESCRIPTION
## Summary
- expose remaining stun and lock time in `StunService`
- forward lock duration to the client
- keep attacker lock locally in `StunStatusClient`
- pass lock duration through `InputController` and `MovementClient`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eee392f28832da35c76a80fd6b297