### PR TITLE
Improve dash cancel behavior on stun

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/StunService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunService.lua
@@ -3,6 +3,7 @@
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local DashModule = require(ReplicatedStorage.Modules.Movement.DashModule)
 
 -- Remotes (may not exist during tests)
 local StunStatusEvent
@@ -193,9 +194,12 @@ function StunService:ApplyStun(targetHumanoid, duration, animOrSkip, attacker, p
         local attackerPlayer = getPlayer(attacker)
         if not targetPlayer or not attackerPlayer then return end
 
-        if DEBUG then
-            print("[StunService] ApplyStun", targetPlayer.Name, "duration", duration, "attacker", attackerPlayer.Name)
-        end
+    if DEBUG then
+        print("[StunService] ApplyStun", targetPlayer.Name, "duration", duration, "attacker", attackerPlayer.Name)
+    end
+
+    -- Stop any active dash immediately when stunned
+    DashModule.CancelDash(targetPlayer)
 
        BlockService.StopBlocking(targetPlayer)
 

--- a/src/ReplicatedStorage/Modules/Movement/DashModule.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashModule.lua
@@ -52,4 +52,16 @@ function DashModule.IsPlayerDashing(player)
 	return activeDashes[player] == true
 end
 
+-- Cancel an active dash early if needed
+function DashModule.CancelDash(player)
+    if activeDashes[player] then
+        activeDashes[player] = nil
+        local char = player.Character
+        local humanoid = char and char:FindFirstChildOfClass("Humanoid")
+        if humanoid then
+            humanoid.AutoRotate = true
+        end
+    end
+end
+
 return DashModule


### PR DESCRIPTION
## Summary
- add DashModule.CancelDash helper
- stop dashes via StunService when a player gets stunned

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3a17d74832db66bde5f2c0c7bff