### PR TITLE
Fix Rokugan ultimate teleport

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/Moves/RokuganClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/RokuganClient.lua
@@ -51,7 +51,7 @@ local function performMove()
     local startCF = hrp.CFrame
     local destCF = startCF * CFrame.new(0, 0, -30)
     hrp.CFrame = destCF
-    StartEvent:FireServer(destCF.Position)
+    StartEvent:FireServer(destCF)
 
     local dir = startCF.LookVector
 

--- a/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
+++ b/src/ReplicatedStorage/Modules/Config/Tools/Rokushiki.lua
@@ -73,6 +73,9 @@ local Rokushiki = {
             Duration = 0.1,
             Shape = "Block",
         },
+        Sound = {
+            Hit = { Id = "rbxassetid://9117969717", Pitch = 1, Volume = 1 },
+        },
     },
 }
 

--- a/src/ServerScriptService/Combat/Rokugan.server.lua
+++ b/src/ServerScriptService/Combat/Rokugan.server.lua
@@ -68,7 +68,7 @@ local function stopAnimation(humanoid)
     activeTracks[humanoid] = nil
 end
 
-StartEvent.OnServerEvent:Connect(function(player, destPos)
+StartEvent.OnServerEvent:Connect(function(player, destCF)
     if DEBUG then print("[Rokugan] StartEvent from", player.Name) end
     local char = player.Character
     local humanoid = char and char:FindFirstChildOfClass("Humanoid")
@@ -95,8 +95,8 @@ StartEvent.OnServerEvent:Connect(function(player, destPos)
         if DEBUG then print("[Rokugan] Not enough stamina") end
         return
     end
-    if typeof(destPos) == "Vector3" then
-        hrp.CFrame = CFrame.new(destPos)
+    if typeof(destCF) == "CFrame" then
+        hrp.CFrame = destCF
     end
 end)
 


### PR DESCRIPTION
## Summary
- teleport server receives a CFrame so orientation is preserved
- send CFrame from RokuganClient
- add missing hit sound for Rokugan ultimate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef8b2b72c832da9830c99aa08b5e6