### PR TITLE
Fix nil function in AssetPreloader

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/AssetPreloader.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/AssetPreloader.client.lua
@@ -19,21 +19,22 @@ local ToolAnimations = require(Animations:WaitForChild("Tool"))
 -- List of asset IDs to preload. Use a set table to avoid duplicates
 local assets = {}
 local seen = {}
+
+-- Utility: Determines if an ID is valid for preloading
+local function isValidAssetId(id)
+    if typeof(id) ~= "string" then return false end
+    if id == "" then return false end
+    if id == "rbxassetid://" then return false end
+    if id:lower():find("placeholder") then return false end
+    if not id:match("^rbxassetid://%d+$") then return false end
+    return true
+end
+
 local function addAsset(id)
     if not seen[id] and isValidAssetId(id) then
         seen[id] = true
         table.insert(assets, id)
     end
-end
-
--- Utility: Determines if an ID is valid for preloading
-local function isValidAssetId(id)
-        if typeof(id) ~= "string" then return false end
-        if id == "" then return false end
-        if id == "rbxassetid://" then return false end
-        if id:lower():find("placeholder") then return false end
-        if not id:match("^rbxassetid://%d+$") then return false end
-        return true
 end
 
 -- 🔊 Preload all valid sound IDs from SoundConfig


### PR DESCRIPTION
## Summary
- define `isValidAssetId` before using it in `addAsset`

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1c020804832da1078352279b30cd