### PR TITLE
Fix blocking break detection

### DIFF
--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -120,10 +120,18 @@ function BlockService.ApplyBlockDamage(player, damage, isBlockBreaker, attackerR
 
        local defenderRoot = player.Character and player.Character:FindFirstChild("HumanoidRootPart")
        if attackerRoot and defenderRoot then
-               local relative = (attackerRoot.Position - defenderRoot.Position).Unit
-               if relative:Dot(defenderRoot.CFrame.LookVector) < 0 then
-                       BlockService.StopBlocking(player)
-                       return nil
+               local relative = attackerRoot.Position - defenderRoot.Position
+               relative = Vector3.new(relative.X, 0, relative.Z)
+               local look = defenderRoot.CFrame.LookVector
+               look = Vector3.new(look.X, 0, look.Z)
+               if relative.Magnitude > 0 and look.Magnitude > 0 then
+                       local dir = relative.Unit
+                       local facing = look.Unit
+                       -- Cancel blocking when struck from behind, do not trigger a break
+                       if dir:Dot(facing) <= -0.7 then
+                               BlockService.StopBlocking(player)
+                               return nil
+                       end
                end
        end
 


### PR DESCRIPTION
## Summary
- refine behind-check for blocking cancellation
- ensure M1 hits from behind cancel blocking without block break

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f37db194c832d98a2d3d1be42c710