### PR TITLE
Fix block damage double counting

### DIFF
--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -146,11 +146,13 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                 params.FilterDescendantsInstances = { char }
 
                 serverTargets = {}
+                local added = {}
                 for _, part in ipairs(workspace:GetPartBoundsInBox(castCF, size, params)) do
                         local model = part:FindFirstAncestorOfClass("Model")
                         local enemyHumanoid = model and model:FindFirstChildOfClass("Humanoid")
                         local enemyPlayer = model and Players:GetPlayerFromCharacter(model)
-                        if enemyHumanoid and enemyPlayer and enemyPlayer ~= player then
+                        if enemyHumanoid and enemyPlayer and enemyPlayer ~= player and not added[enemyPlayer] then
+                                added[enemyPlayer] = true
                                 table.insert(serverTargets, enemyPlayer)
                         end
                 end


### PR DESCRIPTION
## Summary
- prevent duplicate hits from dealing multiple instances of block damage

## Testing
- `rojo build default.project.json -o game.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f41f43f90832d9214587b28aefb57