### PR TITLE
Update overhead bar GUI paths

### DIFF
--- a/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
+++ b/src/ReplicatedStorage/Modules/UI/OverheadBarService.lua
@@ -107,7 +107,10 @@ function onCharacterAdded(player, char)
     end)
     healthGui.Parent = char
 
-    local healthFrame = healthGui:WaitForChild("BarBGMiddle"):WaitForChild("HealthBar")
+    -- Billboard assets were updated so the bar now lives under BG/Bar
+    local healthFrame = healthGui
+        :WaitForChild("BG")
+        :WaitForChild("Bar")
     local healthBase = healthFrame.Size
 
     local blockGui = blockTemplate:Clone()
@@ -116,7 +119,10 @@ function onCharacterAdded(player, char)
     blockGui.Enabled = false
     blockGui.Parent = char
 
-    local blockFrame = blockGui:WaitForChild("BarBGMiddle"):WaitForChild("BlockBar")
+    -- Updated path for block bar inside the billboard
+    local blockFrame = blockGui
+        :WaitForChild("BG")
+        :WaitForChild("Bar")
     local blockBase = blockFrame.Size
 
     local tekkaiGui


### PR DESCRIPTION
## Summary
- update billboard bar paths for Health and Block GUIs

## Testing
- `rojo build default.project.json -o build.rbxlx` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685016a89fa0832d89399f3902f2efc5