### PR TITLE
refactor: harden player spawning and combat events

### DIFF
--- a/src/ServerScriptService/Spawner/RealSpawner.server.lua
+++ b/src/ServerScriptService/Spawner/RealSpawner.server.lua
@@ -1,10 +1,10 @@
 -- ServerScriptService > RealSpawner
 
-local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
 local HealthService = require(ReplicatedStorage.Modules.Stats.HealthService)
 local StaminaService = require(ReplicatedStorage.Modules.Stats.StaminaService)
+local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
 
 -- ✅ Updated remote path
 local Remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -14,64 +14,81 @@ local SpawnRequestEvent = SystemRemotes:WaitForChild("SpawnRequestEvent")
 local TOOLS_FOLDER = ReplicatedStorage:WaitForChild("Tools")
 local hasSpawned = require(script.Parent:WaitForChild("SpawnRegistry"))
 
+-- Cache spawn points so we do not traverse the map on every spawn
+local spawnPoints = {}
 
-local function getRandomSpawnPoint()
-    -- Map is stored directly in Workspace
+local function refreshSpawnPoints()
+    table.clear(spawnPoints)
+
     local map = Workspace:FindFirstChild("Map")
     if not map then
         warn("[RealSpawner] Map not found in Workspace!")
-        return CFrame.new(0, 10, 0)
+        return
     end
 
-	local spawnsFolder = map:FindFirstChild("Spawns")
-	if not spawnsFolder then
-		warn("[RealSpawner] No Spawns folder found under Map!")
-		return CFrame.new(0, 10, 0)
-	end
+    local spawnsFolder = map:FindFirstChild("Spawns")
+    if not spawnsFolder then
+        warn("[RealSpawner] No Spawns folder found under Map!")
+        return
+    end
 
-	local spawnPoints = {}
-	for _, obj in ipairs(spawnsFolder:GetChildren()) do
-		if obj:IsA("BasePart") then
-			table.insert(spawnPoints, obj)
-		end
-	end
+    for _, obj in ipairs(spawnsFolder:GetChildren()) do
+        if obj:IsA("BasePart") then
+            table.insert(spawnPoints, obj)
+        end
+    end
 
-	if #spawnPoints == 0 then
-		warn("[RealSpawner] No spawn points found in Spawns folder!")
-		return CFrame.new(0, 10, 0)
-	end
+    if #spawnPoints == 0 then
+        warn("[RealSpawner] No spawn points found in Spawns folder!")
+    end
+end
 
-	local chosen = spawnPoints[math.random(1, #spawnPoints)]
-	return chosen.CFrame
+refreshSpawnPoints()
+
+local function getRandomSpawnPoint()
+    if #spawnPoints == 0 then
+        return CFrame.new(0, 10, 0)
+    end
+    local chosen = spawnPoints[math.random(#spawnPoints)]
+    return chosen.CFrame
 end
 
 local function spawnPlayerWithTool(player, toolName)
-	print("[RealSpawner] Spawn request from:", player.Name, "Tool:", toolName)
+    if hasSpawned[player] then
+        return
+    end
 
-       local tool = TOOLS_FOLDER:FindFirstChild(toolName)
-       if not tool then
-               warn("[RealSpawner] Tool not found:", toolName)
-		return
-	end
+    if type(toolName) ~= "string" or not ToolConfig.ValidCombatTools[toolName] then
+        warn("[RealSpawner] Invalid tool requested:", toolName)
+        return
+    end
 
-        player:LoadCharacter()
-        local char = player.Character or player.CharacterAdded:Wait()
-        local humanoid = char:FindFirstChildOfClass("Humanoid")
-        if humanoid then
-                HealthService.SetupHumanoid(humanoid)
-        end
-        StaminaService.ResetStamina(player)
-        local hrp = char:WaitForChild("HumanoidRootPart", 5)
+    local tool = TOOLS_FOLDER:FindFirstChild(toolName)
+    if not tool then
+        warn("[RealSpawner] Tool not found:", toolName)
+        return
+    end
 
-	if hrp then
-		hrp.Anchored = false
-		hrp.CFrame = getRandomSpawnPoint()
-	end
+    print("[RealSpawner] Spawn request from:", player.Name, "Tool:", toolName)
 
-	local clone = tool:Clone()
-	clone.Parent = player:WaitForChild("Backpack")
+    player:LoadCharacter()
+    local char = player.Character or player.CharacterAdded:Wait()
+    local humanoid = char:FindFirstChildOfClass("Humanoid")
+    if humanoid then
+        HealthService.SetupHumanoid(humanoid)
+    end
+    StaminaService.ResetStamina(player)
+    local hrp = char:WaitForChild("HumanoidRootPart", 5)
 
-	hasSpawned[player] = true
+    if hrp then
+        hrp.Anchored = false
+        hrp.CFrame = getRandomSpawnPoint()
+    end
+
+    local clone = tool:Clone()
+    clone.Parent = player:WaitForChild("Backpack")
+
+    hasSpawned[player] = true
 end
 
 SpawnRequestEvent.OnServerEvent:Connect(spawnPlayerWithTool)


### PR DESCRIPTION
## Summary
- streamline spawn handling and cache spawn points
- validate requested tools and ignore duplicate spawn requests
- sanitize combat event targets and validate combo indices and tools

## Testing
- `./rojo-bin/rojo build default.project.json -o game.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_689f225b27dc832d9423ece44fd451d7