### PR TITLE
feat: add basic npc combat ai

### DIFF
--- a/src/ReplicatedStorage/Modules/AI/ActionQueue.lua
+++ b/src/ReplicatedStorage/Modules/AI/ActionQueue.lua
@@ -1,75 +1,80 @@
---[[
-    ActionQueue.lua
-    Schedules and executes actions for an NPC in a human-like manner.
-]]
+--ReplicatedStorage.Modules.AI.ActionQueue
+-- Schedules and executes actions with human-like delays.
+
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local ServerScriptService = game:GetService("ServerScriptService")
 
+local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
+local M1Service = require(game.ServerScriptService.Combat.M1Service)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
-local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local DashModule = require(ReplicatedStorage.Modules.Movement.DashModule)
-
-local M1Service
+local ActorAdapter = require(ReplicatedStorage.Modules.AI.ActorAdapter)
 
 local ActionQueue = {}
 ActionQueue.__index = ActionQueue
 
--- Creates a new queue for the given player-like object
-function ActionQueue.new(playerLike)
-    local self = setmetatable({
-        actor = playerLike,
-        queue = {},
-    }, ActionQueue)
-    return self
+function ActionQueue.new(model, bb)
+    local self = {
+        Model = model,
+        Blackboard = bb,
+        Queue = {},
+        ComboStep = 0,
+    }
+    return setmetatable(self, ActionQueue)
 end
 
--- Internal helper to lazily load the M1 service
-local function getM1Service()
-    if not M1Service then
-        M1Service = require(ServerScriptService.Combat.M1Service)
-    end
-    return M1Service
+local function schedule(self, fn)
+    local cfg = self.Blackboard.Config or {}
+    local rt = cfg.ReactionTimeMs or {min = 200, max = 300}
+    local jitter = cfg.MicroJitterMs or {min = 0, max = 0}
+    local delayTime = math.random(rt.min, rt.max) / 1000
+    delayTime += math.random(jitter.min, jitter.max) / 1000
+    table.insert(self.Queue, {Time = tick() + delayTime, Fn = fn})
 end
 
--- Adds an action to the queue
-function ActionQueue:Enqueue(fn, delay)
-    table.insert(self.queue, {time = tick() + (delay or 0), fn = fn})
-end
-
--- Runs due actions
-function ActionQueue:Run()
-    local now = tick()
-    for i = #self.queue, 1, -1 do
-        local item = self.queue[i]
-        if now >= item.time then
-            item.fn()
-            table.remove(self.queue, i)
+function ActionQueue:PressM1()
+    schedule(self, function()
+        self.ComboStep += 1
+        M1Service.ProcessM1Request(self.Model, {step = self.ComboStep})
+        if self.ComboStep >= CombatConfig.M1.ComboHits then
+            self.ComboStep = 0
         end
-    end
-end
-
-function ActionQueue:PressM1(step)
-    self:Enqueue(function()
-        getM1Service().ProcessM1Request(self.actor, {step = step or 1})
-    end, 0)
+    end)
 end
 
 function ActionQueue:StartBlock()
-    self:Enqueue(function()
-        BlockService.StartBlocking(self.actor)
-    end, 0)
+    schedule(self, function()
+        if BlockService.StartBlocking(self.Model) then
+            self.Blackboard.IsBlocking = true
+        end
+    end)
 end
 
 function ActionQueue:ReleaseBlock()
-    self:Enqueue(function()
-        BlockService.StopBlocking(self.actor)
-    end, 0)
+    schedule(self, function()
+        BlockService.StopBlocking(self.Model)
+        self.Blackboard.IsBlocking = false
+    end)
 end
 
-function ActionQueue:Dash(direction, dashVector, styleKey)
-    self:Enqueue(function()
-        DashModule.ExecuteDash(self.actor, direction, dashVector, styleKey)
-    end, 0)
+function ActionQueue:Dash(direction)
+    schedule(self, function()
+        local info = ActorAdapter.Get(self.Model)
+        if not info then return end
+        DashModule.ExecuteDashForModel(info.Character, direction, nil, info.StyleKey)
+    end)
+end
+
+-- Process due actions
+function ActionQueue:Run()
+    local now = tick()
+    local q = self.Queue
+    for i = #q, 1, -1 do
+        local item = q[i]
+        if now >= item.Time then
+            table.remove(q, i)
+            task.spawn(item.Fn)
+        end
+    end
 end
 
 return ActionQueue

--- a/src/ReplicatedStorage/Modules/AI/ActorAdapter.lua
+++ b/src/ReplicatedStorage/Modules/AI/ActorAdapter.lua
@@ -1,0 +1,72 @@
+--ReplicatedStorage.Modules.AI.ActorAdapter
+-- Utility to normalize players and NPC models into a common actor record.
+-- Returns: {Character, Humanoid, StyleKey, Player, IsPlayer, Key}
+
+local ActorAdapter = {}
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
+
+-- Resolves the equipped style based on an attribute or equipped tool
+local function resolveStyle(char)
+    if not char then
+        return "BasicCombat"
+    end
+    local style = char:GetAttribute("StyleKey")
+    if style and ToolConfig.ValidCombatTools[style] then
+        return style
+    end
+    local tool = char:FindFirstChildOfClass("Tool")
+    if tool and ToolConfig.ValidCombatTools[tool.Name] then
+        return tool.Name
+    end
+    return "BasicCombat"
+end
+
+-- Normalize a player or model into an actor table
+-- @param actor Instance Player|Model|Humanoid
+function ActorAdapter.Get(actor)
+    if not actor then
+        return nil
+    end
+    if actor:IsA("Player") then
+        local char = actor.Character
+        local hum = char and char:FindFirstChildOfClass("Humanoid")
+        return {
+            Character = char,
+            Humanoid = hum,
+            StyleKey = resolveStyle(char),
+            Player = actor,
+            IsPlayer = true,
+            Key = actor,
+        }
+    end
+    if actor:IsA("Humanoid") then
+        local char = actor.Parent
+        return {
+            Character = char,
+            Humanoid = actor,
+            StyleKey = resolveStyle(char),
+            Player = Players:GetPlayerFromCharacter(char),
+            IsPlayer = false,
+            Key = actor,
+        }
+    end
+    local model = actor:IsA("Model") and actor or actor:FindFirstAncestorOfClass("Model")
+    if model then
+        local hum = model:FindFirstChildOfClass("Humanoid")
+        local player = Players:GetPlayerFromCharacter(model)
+        return {
+            Character = model,
+            Humanoid = hum,
+            StyleKey = resolveStyle(model),
+            Player = player,
+            IsPlayer = player ~= nil,
+            Key = player or hum,
+        }
+    end
+    return nil
+end
+
+return ActorAdapter

--- a/src/ReplicatedStorage/Modules/AI/Blackboard.lua
+++ b/src/ReplicatedStorage/Modules/AI/Blackboard.lua
@@ -1,67 +1,21 @@
---[[
-    Blackboard.lua
-    Per-NPC memory store used by the combat AI.
-    Exposes helper methods for accessing and tracking state.
-]]
+--ReplicatedStorage.Modules.AI.Blackboard
+-- Simple per-NPC state container.
+
 local Blackboard = {}
 Blackboard.__index = Blackboard
 
--- Creates a new empty blackboard
--- @return Blackboard
-function Blackboard.new()
+-- @param level number AI level 1..5
+-- @param levelConfig table configuration for this level
+function Blackboard.new(level, levelConfig)
     local self = {
+        Level = level,
+        Config = levelConfig,
         Target = nil,
-        LastSeenPos = nil,
-        DistanceBand = "Long",
-        Beliefs = {
-            IsBlocking = false,
-            IsDashing = false,
-            InWindup = false,
-            InRecovery = false,
-            ComboIndex = 0,
-        },
-        Utilities = {},
-        History = {},
-        Cooldowns = {},
-        Stamina = 0,
-        ArchetypeLevel = 1,
-        RNG = Random.new(),
+        TargetDistance = math.huge,
+        IsBlocking = false,
+        LastPerception = 0,
     }
     return setmetatable(self, Blackboard)
-end
-
--- Gets a value from the board
-function Blackboard:Get(key)
-    return self[key]
-end
-
--- Sets a value on the board
-function Blackboard:Set(key, value)
-    self[key] = value
-end
-
--- Pushes a key into a history bucket (for repetition penalties)
-function Blackboard:PushHistory(bucket, key)
-    local hist = self.History[bucket]
-    if not hist then
-        hist = {}
-        self.History[bucket] = hist
-    end
-    hist[key] = (hist[key] or 0) + 1
-end
-
--- Gets the number of times a key has been used in a bucket
-function Blackboard:GetRepeatCount(bucket, key)
-    local hist = self.History[bucket]
-    if not hist then return 0 end
-    return hist[key] or 0
-end
-
--- Clears transient state when stunned
-function Blackboard:ClearOnStun()
-    self.Beliefs.InWindup = false
-    self.Beliefs.InRecovery = false
-    self.Utilities = {}
 end
 
 return Blackboard

--- a/src/ReplicatedStorage/Modules/AI/Decision.lua
+++ b/src/ReplicatedStorage/Modules/AI/Decision.lua
@@ -1,41 +1,46 @@
---[[
-    Decision.lua
-    Very small utility based decision system. Scores a few candidate actions and
-    returns a list ordered by desirability. This is a greatly simplified variant
-    of the design outlined in project docs but keeps the same public surface.
-]]
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local AIConfig = require(ReplicatedStorage.Modules.Config.AIConfig)
+--ReplicatedStorage.Modules.AI.Decision
+-- Simple utility-based decision maker.
 
 local Decision = {}
 
--- Computes a set of desired actions for the NPC
--- @param npc Model
--- @param blackboard Blackboard
--- @return table of action strings
-function Decision.Tick(npc, blackboard)
-    local actions = {}
-    local level = blackboard.ArchetypeLevel or 1
-    local levelCfg = AIConfig.Levels[level] or AIConfig.Levels[1]
-    local dist = blackboard.DistanceBand
+-- Evaluates current state and queues actions.
+-- @param model Model NPC
+-- @param bb Blackboard
+-- @param queue ActionQueue
+function Decision.Tick(model, bb, queue)
+    local target = bb.Target
+    if not target then
+        return
+    end
+    local hrp = model:FindFirstChild("HumanoidRootPart")
+    local targetRoot = target:FindFirstChild("HumanoidRootPart")
+    if not hrp or not targetRoot then
+        return
+    end
+    local dist = (targetRoot.Position - hrp.Position).Magnitude
+    bb.TargetDistance = dist
 
-    if dist == "Ideal" then
-        table.insert(actions, "PressM1")
-    elseif dist == "Long" then
-        table.insert(actions, "DashIn")
-    else -- TooClose
-        if level >= 2 then
-            table.insert(actions, "DashOut")
-        end
+    local hum = model:FindFirstChildOfClass("Humanoid")
+    if hum then
+        hum:MoveTo(targetRoot.Position)
     end
 
-    if level >= 2 and not blackboard.Beliefs.IsBlocking then
-        if math.random() < levelCfg.DashDefense then
-            table.insert(actions, "StartBlock")
-        end
+    -- L1: only basic M1 when close
+    if dist <= 8 then
+        queue:PressM1()
     end
 
-    return actions
+    -- L2+: occasional blocking or dash back
+    if bb.Level >= 2 then
+        local cfg = bb.Config
+        if dist <= 10 and math.random() < (cfg.DashDefense or 0) then
+            queue:Dash("Backward")
+        elseif not bb.IsBlocking and math.random() < 0.1 then
+            queue:StartBlock()
+        elseif bb.IsBlocking and math.random() < 0.05 then
+            queue:ReleaseBlock()
+        end
+    end
 end
 
 return Decision

--- a/src/ReplicatedStorage/Modules/AI/Perception.lua
+++ b/src/ReplicatedStorage/Modules/AI/Perception.lua
@@ -1,66 +1,38 @@
---[[
-    Perception.lua
-    Computes perceptual information for an NPC and writes results to the blackboard.
-    This is intentionally lightweight and avoids any form of hidden information.
-]]
-local Players = game:GetService("Players")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
+--ReplicatedStorage.Modules.AI.Perception
+-- Naive perception: finds nearest alive player.
 
-local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
-local MoveHitboxConfig = require(ReplicatedStorage.Modules.Config.MoveHitboxConfig)
-local AIConfig = require(ReplicatedStorage.Modules.Config.AIConfig)
+local Players = game:GetService("Players")
 
 local Perception = {}
 
--- Determines distance band for given NPC/target pair
-local function computeDistanceBand(npc, target)
-    local npcRoot = npc and npc:FindFirstChild("HumanoidRootPart")
-    local targetRoot = target and target:FindFirstChild("HumanoidRootPart")
-    if not npcRoot or not targetRoot then
-        return "Long"
+-- Updates blackboard with nearest target information.
+-- @param bb Blackboard
+-- @param model Model NPC character
+function Perception.Update(bb, model)
+    local hrp = model and model:FindFirstChild("HumanoidRootPart")
+    if not hrp then
+        bb.Target = nil
+        bb.TargetDistance = math.huge
+        return
     end
-    local dist = (npcRoot.Position - targetRoot.Position).Magnitude
-    -- Generic thresholds if tool data not present
-    local idealMin, idealMax = 4, 8
-    local tool = npc:FindFirstChildOfClass("Tool")
-    if tool then
-        local meta = ToolConfig.ToolMeta[tool.Name]
-        if meta and meta.IdealDistanceBand then
-            -- IdealDistanceBand can be a table {min,max}
-            if typeof(meta.IdealDistanceBand) == "table" then
-                idealMin = meta.IdealDistanceBand[1] or idealMin
-                idealMax = meta.IdealDistanceBand[2] or idealMax
-            end
-        else
-            local hb = MoveHitboxConfig[tool.Name]
-            if hb and hb.M1 and hb.M1.Range then
-                idealMax = hb.M1.Range
-            end
-        end
-    end
-    if dist < idealMin then
-        return "TooClose"
-    elseif dist <= idealMax then
-        return "Ideal"
-    end
-    return "Long"
-end
 
--- Updates the blackboard based on current world state
-function Perception.Update(npc, blackboard)
-    local target = blackboard.Target
-    if target then
-        blackboard.LastSeenPos = target.PrimaryPart and target.PrimaryPart.Position or blackboard.LastSeenPos
-        blackboard.DistanceBand = computeDistanceBand(npc, target)
-        -- Basic beliefs from observable humanoid states
-        local hum = target:FindFirstChildOfClass("Humanoid")
-        if hum then
-            blackboard.Beliefs.IsBlocking = hum:FindFirstChild("Block") and hum.Block.Value or false
-            blackboard.Beliefs.IsDashing = hum:FindFirstChild("Dash") and hum.Dash.Value or false
+    local nearest
+    local nearestDist = math.huge
+    for _, p in ipairs(Players:GetPlayers()) do
+        local char = p.Character
+        local hum = char and char:FindFirstChildOfClass("Humanoid")
+        local root = char and char:FindFirstChild("HumanoidRootPart")
+        if hum and hum.Health > 0 and root then
+            local d = (root.Position - hrp.Position).Magnitude
+            if d < nearestDist then
+                nearest = char
+                nearestDist = d
+            end
         end
-    else
-        blackboard.DistanceBand = "Long"
     end
+
+    bb.Target = nearest
+    bb.TargetDistance = nearestDist
 end
 
 return Perception

--- a/src/ReplicatedStorage/Modules/Config/AIConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/AIConfig.lua
@@ -1,3 +1,6 @@
+--ReplicatedStorage.Modules.Config.AIConfig
+-- Configuration for NPC combat AI levels.
+
 return {
   PerceptionHz = 15,
   DecisionHz   = 7,

--- a/src/ReplicatedStorage/Modules/Movement/DashModule.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashModule.lua
@@ -47,6 +47,44 @@ function DashModule.ExecuteDash(player, direction, dashVector, styleKey)
 	end)
 end
 
+-- Mirror of ExecuteDash but operates on a model/NPC instead of a player
+-- @param model Model
+-- @param direction string dash direction
+-- @param dashVector Vector3? unused for now
+-- @param styleKey string combat style
+function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
+        if activeDashes[model] then
+                return
+        end
+        activeDashes[model] = true
+
+        local humanoid = model:FindFirstChildOfClass("Humanoid")
+        if humanoid and (
+                direction == "Left"
+                or direction == "Right"
+                or direction == "Backward"
+                or direction == "BackwardLeft"
+                or direction == "BackwardRight"
+        ) then
+                humanoid.AutoRotate = false
+        end
+
+        local dashSet = DashConfig.Settings
+        if styleKey == "Rokushiki" then
+                dashSet = DashConfig.RokuSettings
+        end
+        local dashSettings = dashSet[direction] or dashSet["Forward"]
+        local duration = dashSettings and dashSettings.Duration or 0.25
+
+        task.delay(duration, function()
+                activeDashes[model] = nil
+                local hum = model:FindFirstChildOfClass("Humanoid")
+                if hum then
+                        hum.AutoRotate = true
+                end
+        end)
+end
+
 -- Helper to check dash state
 function DashModule.IsPlayerDashing(player)
 	return activeDashes[player] == true

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -222,10 +222,7 @@ HitConfirmEvent.OnServerEvent:Connect(function(player, targetPlayers, comboIndex
                         continue
                 end
 
-               local blockResult
-               if enemyPlayer then
-                       blockResult = BlockService.ApplyBlockDamage(enemyPlayer, damage, false, hrp)
-               end
+               local blockResult = BlockService.ApplyBlockDamage(target.Key, damage, false, hrp)
                if blockResult == "Perfect" then
                         blockHit = true
                         StunService:ApplyStun(humanoid, BlockService.GetPerfectBlockStunDuration(), AnimationData.Stun.PerfectBlock, player)

--- a/src/ServerScriptService/Combat/M1Service.lua
+++ b/src/ServerScriptService/Combat/M1Service.lua
@@ -12,6 +12,7 @@ local AnimationData = require(ReplicatedStorage.Modules.Animations.Combat)
 local StunService = require(ReplicatedStorage.Modules.Combat.StunService)
 local BlockService = require(ReplicatedStorage.Modules.Combat.BlockService)
 local AnimationUtils = require(ReplicatedStorage.Modules.Effects.AnimationUtils)
+local ActorAdapter = require(ReplicatedStorage.Modules.AI.ActorAdapter)
 
 local M1Service = {}
 local comboTimestamps = {}
@@ -34,40 +35,51 @@ end
 -- Processes an M1 request exactly as the RemoteEvent handler would
 -- @param player Player-like object (must have Character)
 -- @param payload table from client containing combo step and aim info
-function M1Service.ProcessM1Request(player, payload)
+function M1Service.ProcessM1Request(actor, payload)
     local comboIndex
     if typeof(payload) == "table" then
         comboIndex = payload.step or payload[1]
     else
         comboIndex = payload
     end
-    if typeof(comboIndex) ~= "number" then return end
+    if typeof(comboIndex) ~= "number" then
+        return
+    end
     comboIndex = math.floor(comboIndex)
-    if comboIndex < 1 or comboIndex > CombatConfig.M1.ComboHits then return end
+    if comboIndex < 1 or comboIndex > CombatConfig.M1.ComboHits then
+        return
+    end
 
-    local char = player.Character
-    if not char then return end
-    local humanoid = char:FindFirstChildOfClass("Humanoid")
-    if not humanoid then return end
-    if StunService:IsStunned(player) or StunService:IsAttackerLocked(player) then return end
-    if BlockService.IsBlocking(player) or BlockService.IsInStartup(player) then return end
+    local info = ActorAdapter.Get(actor)
+    if not info or not info.Character or not info.Humanoid then
+        return
+    end
+    local key = info.Key
+    if StunService:IsStunned(key) or StunService:IsAttackerLocked(key) then
+        return
+    end
+    if BlockService.IsBlocking(key) or BlockService.IsInStartup(key) then
+        return
+    end
 
     local now = tick()
-    comboTimestamps[player] = comboTimestamps[player] or { LastClick = 0, CooldownEnd = 0 }
-    local state = comboTimestamps[player]
+    comboTimestamps[key] = comboTimestamps[key] or { LastClick = 0, CooldownEnd = 0 }
+    local state = comboTimestamps[key]
 
-    if now < state.CooldownEnd then return end
+    if now < state.CooldownEnd then
+        return
+    end
     state.LastClick = now
     if comboIndex == CombatConfig.M1.ComboHits then
         state.CooldownEnd = now + CombatConfig.M1.ComboCooldown
     end
 
-    local tool = char:FindFirstChildOfClass("Tool")
+    local tool = info.Character:FindFirstChildOfClass("Tool")
     local styleKey = getStyleKeyFromTool(tool)
     local animSet = AnimationData.M1[styleKey]
     local animId = animSet and animSet.Combo and animSet.Combo[comboIndex]
     if animId then
-        playAnimation(humanoid, animId)
+        playAnimation(info.Humanoid, animId)
     end
 end
 


### PR DESCRIPTION
## Summary
- add configurable AI levels and brain modules
- support model actors in combat helpers and dashing
- spawn NPC brains for `Enemy - N` models with random combat styles

## Testing
- `luau --version` *(fails: command not found)*
- `rojo build --output build.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ea93d50832da5c4381bbc0e7183