### PR TITLE
Allow NPCs and players to share combat logic

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashModule.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashModule.lua
@@ -1,64 +1,32 @@
 -- ReplicatedStorage.Modules.Movement.DashModule
 
 local DashConfig = require(script.Parent.DashConfig)
+local ActorAdapter = require(game.ReplicatedStorage.Modules.AI.ActorAdapter)
 local DashModule = {}
 
 local activeDashes = {}
 
--- Called when a dash is requested (just mark dash state & lock autorotate for side/back/diagonal-back)
--- styleKey specifies the equipped combat style, e.g. "Rokushiki". It allows
--- style-specific dash behaviour such as different durations.
-function DashModule.ExecuteDash(player, direction, dashVector, styleKey)
-	if activeDashes[player] then
-		-- Already dashing, ignore
-		return
-	end
-	activeDashes[player] = true
-
-	local character = player.Character
-	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
-
-	-- Lock AutoRotate for all non-steerable directions
-	if humanoid and (
-		direction == "Left"
-			or direction == "Right"
-			or direction == "Backward"
-			or direction == "BackwardLeft"
-			or direction == "BackwardRight"
-		) then
-		humanoid.AutoRotate = false
-	end
-
-        local dashSet = DashConfig.Settings
-        if styleKey == "Rokushiki" then
-                dashSet = DashConfig.RokuSettings
+local function resolve(actor)
+        local info = ActorAdapter.Get(actor)
+        if not info or not info.Character or not info.Humanoid then
+                return nil, nil, nil
         end
-        local dashSettings = dashSet[direction] or dashSet["Forward"]
-        local duration = dashSettings and dashSettings.Duration or 0.25
-
-	-- End dash after duration, unlock autorotate if needed
-	task.delay(duration, function()
-		activeDashes[player] = nil
-		local char = player.Character
-		local hum = char and char:FindFirstChildOfClass("Humanoid")
-		if hum then
-			hum.AutoRotate = true
-		end
-	end)
+        return info.Character, info.Humanoid, info.StyleKey
 end
 
--- Mirror of ExecuteDash but operates on a model/NPC instead of a player
--- @param model Model
--- @param direction string dash direction
--- @param dashVector Vector3? unused for now
--- @param styleKey string combat style
-function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
-        if activeDashes[model] then
+-- Called when a dash is requested. Works for players or NPC models.
+-- styleKey specifies the equipped combat style, e.g. "Rokushiki".
+function DashModule.ExecuteDash(actor, direction, dashVector, styleKey)
+        local key, humanoid, resolvedStyle = resolve(actor)
+        if not key then
                 return
         end
-        activeDashes[model] = true
+        if activeDashes[key] then
+                return
+        end
+        activeDashes[key] = true
 
-        local humanoid = model:FindFirstChildOfClass("Humanoid")
+        -- Lock AutoRotate for all non-steerable directions
         if humanoid and (
                 direction == "Left"
                 or direction == "Right"
@@ -70,6 +38,7 @@ function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
         end
 
         local dashSet = DashConfig.Settings
+        styleKey = styleKey or resolvedStyle
         if styleKey == "Rokushiki" then
                 dashSet = DashConfig.RokuSettings
         end
@@ -77,29 +46,36 @@ function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
         local duration = dashSettings and dashSettings.Duration or 0.25
 
         task.delay(duration, function()
-                activeDashes[model] = nil
-                local hum = model:FindFirstChildOfClass("Humanoid")
+                activeDashes[key] = nil
+                local hum = ActorAdapter.GetHumanoid(actor)
                 if hum then
                         hum.AutoRotate = true
                 end
         end)
 end
 
--- Helper to check dash state
-function DashModule.IsPlayerDashing(player)
-	return activeDashes[player] == true
+-- Backwards compatibility wrapper for old NPC API
+function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
+        DashModule.ExecuteDash(model, direction, dashVector, styleKey)
 end
 
+-- Helper to check dash state
+function DashModule.IsDashing(actor)
+        local key = resolve(actor)
+        return key and activeDashes[key] == true
+end
+
+DashModule.IsPlayerDashing = DashModule.IsDashing
+
 -- Cancel an active dash early if needed
-function DashModule.CancelDash(player)
-    if activeDashes[player] then
-        activeDashes[player] = nil
-        local char = player.Character
-        local humanoid = char and char:FindFirstChildOfClass("Humanoid")
-        if humanoid then
-            humanoid.AutoRotate = true
+function DashModule.CancelDash(actor)
+        local key, humanoid = resolve(actor)
+        if key and activeDashes[key] then
+                activeDashes[key] = nil
+                if humanoid then
+                        humanoid.AutoRotate = true
+                end
         end
-    end
 end
 
 return DashModule

--- a/src/ServerScriptService/Combat/CombatService.server.lua
+++ b/src/ServerScriptService/Combat/CombatService.server.lua
@@ -1,5 +1,6 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ActorAdapter = require(ReplicatedStorage.Modules.AI.ActorAdapter)
 
 local M1Service = require(script.Parent.M1Service)
 local comboTimestamps = M1Service.ComboTimestamps
@@ -9,8 +10,11 @@ local CombatRemotes = Remotes:WaitForChild("Combat")
 local M1Event = CombatRemotes:WaitForChild("M1Event")
 local HitConfirmEvent = CombatRemotes:WaitForChild("HitConfirmEvent")
 
-local function cleanup(player)
-    comboTimestamps[player] = nil
+local function cleanup(actor)
+    local char = ActorAdapter.GetCharacter(actor)
+    if char then
+        comboTimestamps[char] = nil
+    end
 end
 
 Players.PlayerRemoving:Connect(cleanup)


### PR DESCRIPTION
## Summary
- Normalize actors into shared records with style and root info
- Track block, stun, and dash state by character so NPCs and players use the same services
- Rework melee handler to resolve targets generically and apply hit logic to models

## Testing
- `rojo --version` *(fails: command not found)*
- `selene --version` *(fails: command not found)*
- `stylua --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9932f5c0832d8b5c6479aadc3db2