### PR TITLE
feat: allow combat services to handle actors

### DIFF
--- a/src/ReplicatedStorage/Modules/AI/ActorAdapter.lua
+++ b/src/ReplicatedStorage/Modules/AI/ActorAdapter.lua
@@ -5,20 +5,17 @@
 local ActorAdapter = {}
 
 local Players = game:GetService("Players")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
-
 -- Resolves the equipped style based on an attribute or equipped tool
 local function resolveStyle(char)
     if not char then
         return "BasicCombat"
     end
     local style = char:GetAttribute("StyleKey")
-    if style and ToolConfig.ValidCombatTools[style] then
+    if typeof(style) == "string" and style ~= "" then
         return style
     end
     local tool = char:FindFirstChildOfClass("Tool")
-    if tool and ToolConfig.ValidCombatTools[tool.Name] then
+    if tool then
         return tool.Name
     end
     return "BasicCombat"

--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -53,6 +53,17 @@ function BlockService.GetBlockHP(actor)
        return BlockHP[key] or PlayerStats.BlockHP
 end
 
+function BlockService.SetBlockHP(actor, value)
+       local key, info = resolve(actor)
+       if not key then
+               return
+       end
+       BlockHP[key] = value
+       if info and info.IsPlayer then
+               OverheadBarService.UpdateBlock(info.Player, value)
+       end
+end
+
 function BlockService.GetPerfectBlockStunDuration()
 	return CombatConfig.Blocking.PerfectBlockStunDuration or 6
 end

--- a/src/ReplicatedStorage/Modules/Movement/DashModule.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashModule.lua
@@ -14,9 +14,7 @@ local function resolve(actor)
         return info.Character, info.Humanoid, info.StyleKey
 end
 
--- Called when a dash is requested. Works for players or NPC models.
--- styleKey specifies the equipped combat style, e.g. "Rokushiki".
-function DashModule.ExecuteDash(actor, direction, dashVector, styleKey)
+local function execute(actor, direction, dashVector, styleKey)
         local key, humanoid, resolvedStyle = resolve(actor)
         if not key then
                 return
@@ -54,9 +52,14 @@ function DashModule.ExecuteDash(actor, direction, dashVector, styleKey)
         end)
 end
 
--- Backwards compatibility wrapper for old NPC API
+-- Called when a player requests a dash.
+function DashModule.ExecuteDash(player, direction, dashVector, styleKey)
+        execute(player, direction, dashVector, styleKey)
+end
+
+-- Mirrors ExecuteDash but accepts an NPC model.
 function DashModule.ExecuteDashForModel(model, direction, dashVector, styleKey)
-        DashModule.ExecuteDash(model, direction, dashVector, styleKey)
+        execute(model, direction, dashVector, styleKey)
 end
 
 -- Helper to check dash state


### PR DESCRIPTION
## Summary
- normalize players and NPC models with new ActorAdapter utility
- key combat state by character models and expose block HP setter
- adjust stun tracking & remotes to only target real players; add LockFor alias
- share dash code for players and NPCs with ExecuteDashForModel

## Testing
- `rojo sourcemap default.project.json | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_689feb859aa0832d92577c12a02d46f8