### PR TITLE
Replace tick with monotonic Time helper

### DIFF
--- a/src/ReplicatedStorage/Modules/AI/ActionQueue.lua
+++ b/src/ReplicatedStorage/Modules/AI/ActionQueue.lua
@@ -2,6 +2,7 @@
 -- Schedules and executes actions with human-like delays.
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local M1Service = require(game.ServerScriptService.Combat.M1Service)
@@ -28,7 +29,7 @@ local function schedule(self, fn)
     local jitter = cfg.MicroJitterMs or {min = 0, max = 0}
     local delayTime = math.random(rt.min, rt.max) / 1000
     delayTime += math.random(jitter.min, jitter.max) / 1000
-    table.insert(self.Queue, {Time = tick() + delayTime, Fn = fn})
+    table.insert(self.Queue, {Time = Time.now() + delayTime, Fn = fn})
 end
 
 function ActionQueue:PressM1()
@@ -66,7 +67,7 @@ end
 
 -- Process due actions
 function ActionQueue:Run()
-    local now = tick()
+    local now = Time.now()
     local q = self.Queue
     for i = #q, 1, -1 do
         local item = q[i]

--- a/src/ReplicatedStorage/Modules/Client/JumpController.lua
+++ b/src/ReplicatedStorage/Modules/Client/JumpController.lua
@@ -6,6 +6,7 @@ local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 local BlockClient = require(ReplicatedStorage.Modules.Combat.BlockClient)
@@ -36,7 +37,7 @@ end
 -- ⏱ Begin jump cooldown
 function JumpController.StartCooldown(duration)
 	local time = duration or JUMP_COOLDOWN
-	jumpBlockedUntil = tick() + time
+	jumpBlockedUntil = Time.now() + time
 	if DEBUG then print("[JumpController] Jump cooldown started:", time, "s") end
 
         if cooldownTask then
@@ -46,7 +47,7 @@ function JumpController.StartCooldown(duration)
 
         blockJump()
         cooldownTask = task.delay(time, function()
-                if tick() >= jumpBlockedUntil then
+                if Time.now() >= jumpBlockedUntil then
                         restoreJump()
                         cooldownTask = nil
                 end
@@ -60,8 +61,8 @@ local function onJumpRequest()
                 blockJump()
                 return
         end
-        if tick() < jumpBlockedUntil then
-                if DEBUG then print("[JumpController] Jump blocked. Time left:", jumpBlockedUntil - tick()) end
+        if Time.now() < jumpBlockedUntil then
+                if DEBUG then print("[JumpController] Jump blocked. Time left:", jumpBlockedUntil - Time.now()) end
                 blockJump()
         else
                 humanoid:ChangeState(Enum.HumanoidStateType.Jumping)

--- a/src/ReplicatedStorage/Modules/Client/MovementClient.lua
+++ b/src/ReplicatedStorage/Modules/Client/MovementClient.lua
@@ -4,6 +4,7 @@ local MovementClient = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local player = Players.LocalPlayer
 local character = player.Character or player.CharacterAdded:Wait()
@@ -70,7 +71,7 @@ function MovementClient.OnInputBegan(input, gameProcessed)
 	end
 
 	if key == "W" then
-		local now = tick()
+		local now = Time.now()
 		if now - lastWPress <= 0.3 and not sprinting then
 			beginSprint()
 		end

--- a/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockClient.lua
@@ -5,6 +5,7 @@ local BlockClient = {}
 local UserInputService = game:GetService("UserInputService")
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local RunService = game:GetService("RunService")
 
 local player = Players.LocalPlayer
@@ -100,7 +101,7 @@ BlockEvent.OnClientEvent:Connect(function(active)
                         activeVFX = BlockVFX.Create(hrp)
                 end
         else
-                lastBlockEnd = tick()
+                lastBlockEnd = Time.now()
                 stopBlockAnimation()
                 MoveListManager.StartCooldown(Enum.KeyCode.F.Name, blockCooldown)
         end
@@ -163,7 +164,7 @@ end
 local function attemptBlock()
        if not blockHeld or isBlocking then return end
        if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
-       local now = tick()
+       local now = Time.now()
        if now < blockDisabledUntil then return end
        if now - lastBlockEnd < blockCooldown then return end
        if not HasValidBlockingTool() then return end
@@ -219,7 +220,7 @@ function BlockClient.OnInputEnded(input, gameProcessed)
        if not isBlocking then return end
 
        isBlocking = false
-       lastBlockEnd = tick()
+       lastBlockEnd = Time.now()
        stopBlockAnimation()
        BlockEvent:FireServer(false)
 end
@@ -231,7 +232,7 @@ end
 -- Prevent starting a block for the given duration (in seconds)
 function BlockClient.DisableFor(duration)
         if typeof(duration) ~= "number" or duration <= 0 then return end
-        local endTime = tick() + duration
+        local endTime = Time.now() + duration
         if endTime > blockDisabledUntil then
                 blockDisabledUntil = endTime
         end

--- a/src/ReplicatedStorage/Modules/Combat/BlockService.lua
+++ b/src/ReplicatedStorage/Modules/Combat/BlockService.lua
@@ -3,6 +3,7 @@
 local BlockService = {}
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local PersistentStats = require(ReplicatedStorage.Modules.Stats.PersistentStatsService)
 local Players = game:GetService("Players")
 
@@ -22,7 +23,7 @@ local BlockEvent = combatFolder:WaitForChild("BlockEvent")
 -- 🧠 Block state
 local BlockingPlayers = {}    -- [char] = true/false
 local BlockHP = {}            -- [char] = number
-local PerfectBlockTimers = {} -- [char] = tick()
+local PerfectBlockTimers = {} -- [char] = Time.now()
 local BlockCooldowns = {}     -- [char] = time
 local BlockStartup = {}       -- [char] = true
 
@@ -75,7 +76,7 @@ end
 function BlockService.IsOnCooldown(actor)
        local key = resolve(actor)
        local t = key and BlockCooldowns[key]
-       return t and tick() < t
+       return t and Time.now() < t
 end
 
 -- 🛡️ Called when player starts blocking
@@ -98,7 +99,7 @@ function BlockService.StartBlocking(actor)
 				BlockStartup[key] = nil
 				BlockHP[key] = PlayerStats.BlockHP
 				BlockingPlayers[key] = true
-				PerfectBlockTimers[key] = tick()
+				PerfectBlockTimers[key] = Time.now()
 				if info and info.IsPlayer then
 					OverheadBarService.SetBlockActive(info.Player, true)
 					OverheadBarService.UpdateBlock(info.Player, PlayerStats.BlockHP)
@@ -120,7 +121,7 @@ function BlockService.StopBlocking(actor)
        local hadBlock = BlockingPlayers[key] or BlockStartup[key]
 
        if hadBlock and BlockingPlayers[key] then
-               BlockCooldowns[key] = tick() + (CombatConfig.Blocking.BlockCooldown or 2)
+               BlockCooldowns[key] = Time.now() + (CombatConfig.Blocking.BlockCooldown or 2)
        end
 
        BlockingPlayers[key] = nil
@@ -176,7 +177,7 @@ function BlockService.ApplyBlockDamage(actor, damage, isBlockBreaker, attackerRo
        end
 
        local hp = BlockHP[key] or 0
-       local timeSinceStart = tick() - (PerfectBlockTimers[key] or 0)
+       local timeSinceStart = Time.now() - (PerfectBlockTimers[key] or 0)
 
        -- 🌀 Perfect block window takes priority even against block breakers
        if timeSinceStart <= CombatConfig.Blocking.PerfectBlockWindow then

--- a/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/HitboxClient.lua
@@ -4,6 +4,7 @@ local HitboxClient = {}
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local Debris = game:GetService("Debris")
 local Workspace = game:GetService("Workspace")
 
@@ -107,11 +108,11 @@ function HitboxClient.CastHitbox(
     local alreadyHit = {}
         local overlapParams = getOverlapParams(char)
 
-	local startTime = tick()
+	local startTime = Time.now()
 	local connection
 
         connection = RunService.RenderStepped:Connect(function()
-                local elapsed = tick() - startTime
+                local elapsed = Time.now() - startTime
                 local progress = math.clamp(elapsed / duration, 0, 1)
                 if travelDistance and travelDistance ~= 0 then
                         hitbox.CFrame = originCF + dir * travelDistance * progress

--- a/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/M1InputClient.lua
@@ -4,6 +4,7 @@ local M1InputClient = {}
 local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local player = Players.LocalPlayer
 local Remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -31,7 +32,7 @@ function M1InputClient.OnInputBegan(input, gameProcessed)
 
 	-- 🖱️ Handle M1
 	if input.UserInputType == Enum.UserInputType.MouseButton1 then
-		local now = tick()
+		local now = Time.now()
                 if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() or BlockClient.IsBlocking() or isAwaitingServer then return end
 		if now - lastClick < CombatConfig.M1.DelayBetweenHits then return end
 

--- a/src/ReplicatedStorage/Modules/Combat/Moves/AntiMannerKickCourseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/AntiMannerKickCourseClient.lua
@@ -3,6 +3,7 @@ local AntiMannerKickCourse = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 
 local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
@@ -103,10 +104,10 @@ function AntiMannerKickCourse.OnInputBegan(input, gp)
 
     if UltService.GetUlt(Players.LocalPlayer) < UltService.GetMaxUlt(Players.LocalPlayer) then return end
 
-    if tick() - lastUse < (MoveConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (MoveConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, MoveConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ConcasseClient.lua
@@ -3,6 +3,7 @@ local Concasse = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
@@ -130,11 +131,11 @@ local function performMove(targetPos)
         look = look.Unit
     end
 
-    local startTime = tick()
+    local startTime = Time.now()
     local lastPos = start
     local airborne = humanoid.FloorMaterial == Enum.Material.Air
-    while tick() - startTime < travelTime do
-        local t = (tick() - startTime) / travelTime
+    while Time.now() - startTime < travelTime do
+        local t = (Time.now() - startTime) / travelTime
         local nextPos = start:Lerp(dest, t)
         nextPos += Vector3.new(0, math.sin(math.pi * t) * height, 0)
         local result = Workspace:Raycast(lastPos, nextPos - lastPos, params)
@@ -189,10 +190,10 @@ function Concasse.OnInputBegan(input, gp)
 
     if StaminaService.GetStamina(player) < 20 then return end
 
-    if tick() - lastUse < (ConcasseConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (ConcasseConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, ConcasseConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PartyTableKickClient.lua
@@ -3,6 +3,7 @@ local PartyTableKick = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
@@ -105,9 +106,9 @@ local function performMove()
         cleanup()
     end
 
-    local startTime = tick()
+    local startTime = Time.now()
     local canCancel = cfg.Cancelable ~= false
-    while tick() - startTime < cfg.Startup do
+    while Time.now() - startTime < cfg.Startup do
         if not held or (canCancel and not cfg.HyperArmor and StunStatusClient.IsStunned()) then
             if DEBUG then print("[PartyTableKickClient] Startup cancelled") end
             endMove()
@@ -136,8 +137,8 @@ local function performMove()
             PartyTableKickVFX.Create(hitbox)
         end
         if i < cfg.Hits then
-            local waitStart = tick()
-            while tick() - waitStart < interval do
+            local waitStart = Time.now()
+            while Time.now() - waitStart < interval do
                 if not held or (canCancel and StunStatusClient.IsStunned()) then
                     endMove()
                     return
@@ -182,7 +183,7 @@ function PartyTableKick.OnInputBegan(input, gp)
         return
     end
     local cfg = PartyTableKickConfig
-    if tick() - lastUse < (cfg.Cooldown or 0) then
+    if Time.now() - lastUse < (cfg.Cooldown or 0) then
         if DEBUG then print("[PartyTableKickClient] On cooldown") end
         return
     end
@@ -190,7 +191,7 @@ function PartyTableKick.OnInputBegan(input, gp)
     if DEBUG then print("[PartyTableKickClient] Move initiated") end
     held = true
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, cfg.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerKickClient.lua
@@ -3,6 +3,7 @@ local PowerKick = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
@@ -106,10 +107,10 @@ function PowerKick.OnInputBegan(input, gp)
 
     if StaminaService.GetStamina(Players.LocalPlayer) < 20 then return end
 
-    if tick() - lastUse < (PowerKickConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (PowerKickConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, PowerKickConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/PowerPunchClient.lua
@@ -3,6 +3,7 @@ local PowerPunch = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 local Debris = game:GetService("Debris")
@@ -144,10 +145,10 @@ function PowerPunch.OnInputBegan(input, gp)
 
     if StaminaService.GetStamina(Players.LocalPlayer) < 20 then return end
 
-    if tick() - lastUse < (PowerPunchConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (PowerPunchConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, PowerPunchConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/RokuganClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/RokuganClient.lua
@@ -3,6 +3,7 @@ local Rokugan = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 
 local CombatRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
@@ -85,10 +86,10 @@ function Rokugan.OnInputBegan(input, gp)
     if StaminaService.GetStamina(player) < (MoveConfig.StaminaCost or 0) then return end
     if UltService.GetUlt(player) < UltService.GetMaxUlt(player) then return end
 
-    if tick() - lastUse < (MoveConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (MoveConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, MoveConfig.Cooldown or 0)
 
     local lockTime = (MoveConfig.Startup or 0) + (MoveConfig.Endlag or 0)

--- a/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/ShiganClient.lua
@@ -3,6 +3,7 @@ local Shigan = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
@@ -103,10 +104,10 @@ function Shigan.OnInputBegan(input, gp)
     if style ~= "Rokushiki" then return end
     if not ToolController.IsValidCombatTool() then return end
 
-    if tick() - lastUse < (ShiganConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (ShiganConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, ShiganConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TekkaiClient.lua
@@ -3,6 +3,7 @@ local Tekkai = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 
 local player = Players.LocalPlayer
@@ -90,7 +91,7 @@ function Tekkai.OnInputBegan(input, gp)
     if gp then return end
     if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
     if active then return end
-    if tick() - lastUse < (TekkaiConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (TekkaiConfig.Cooldown or 0) then return end
     if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() then return end
     if BlockClient.IsBlocking() then return end
     local style = ToolController.GetEquippedStyleKey()
@@ -104,7 +105,7 @@ function Tekkai.OnInputBegan(input, gp)
         prevJump = humanoid.JumpPower
     end
     MovementClient.StopSprint()
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, TekkaiConfig.Cooldown or 0)
     TekkaiEvent:FireServer(true)
 end

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TeleportClient.lua
@@ -3,6 +3,7 @@ local Teleport = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 
 local MovementRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Movement")
@@ -36,7 +37,7 @@ end
 function Teleport.OnInputBegan(input, gp)
     if input.UserInputType ~= Enum.UserInputType.Keyboard or input.KeyCode ~= KEY then return end
     if active then return end
-    if tick() - lastUse < (TeleportConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (TeleportConfig.Cooldown or 0) then return end
     if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() or BlockClient.IsBlocking() then return end
 
     local style = ToolController.GetEquippedStyleKey()
@@ -49,7 +50,7 @@ function Teleport.OnInputBegan(input, gp)
     if not hrp or not humanoid then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, TeleportConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/Moves/TempestKickClient.lua
@@ -3,6 +3,7 @@ local TempestKick = {}
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
@@ -124,10 +125,10 @@ function TempestKick.OnInputBegan(input, gp)
 
     if StaminaService.GetStamina(Players.LocalPlayer) < 75 then return end
 
-    if tick() - lastUse < (TempestKickConfig.Cooldown or 0) then return end
+    if Time.now() - lastUse < (TempestKickConfig.Cooldown or 0) then return end
 
     active = true
-    lastUse = tick()
+    lastUse = Time.now()
     MoveListManager.StartCooldown(KEY.Name, TempestKickConfig.Cooldown or 0)
 
     MovementClient.StopSprint()

--- a/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
+++ b/src/ReplicatedStorage/Modules/Combat/StunStatusClient.lua
@@ -1,6 +1,7 @@
 --ReplicatedStorage.Modules.Combat.StunStatusClient
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local Config = require(ReplicatedStorage.Modules.Config.Config)
 
 local StunStatusClient = {}
@@ -16,7 +17,7 @@ local stunEndTime = 0
 
 -- Helper to get remaining local lock duration
 local function getRemaining()
-    return math.max(0, localLockUntil - tick())
+    return math.max(0, localLockUntil - Time.now())
 end
 
 -- Getter functions (to be called)
@@ -25,7 +26,7 @@ function StunStatusClient.IsStunned()
 end
 
 function StunStatusClient.IsAttackerLocked()
-        return serverLocked or tick() < localLockUntil
+        return serverLocked or Time.now() < localLockUntil
 end
 
 function StunStatusClient.IsGuardBroken()
@@ -47,10 +48,10 @@ function StunStatusClient.SetStatus(stunned, locked, lockRemaining, isGuardBroke
         serverLocked = locked
         guardBroken = isGuardBrokenRemote or false
         if typeof(stunRemaining) == "number" then
-            stunEndTime = tick() + math.max(0, stunRemaining)
+            stunEndTime = Time.now() + math.max(0, stunRemaining)
         end
         if typeof(lockRemaining) == "number" and lockRemaining > 0 then
-            localLockUntil = math.max(localLockUntil, tick() + lockRemaining)
+            localLockUntil = math.max(localLockUntil, Time.now() + lockRemaining)
         end
         if DEBUG then
             print("[StunStatusClient] Status update", stunned, locked, lockRemaining, guardBroken, stunRemaining)
@@ -59,7 +60,7 @@ end
 
 function StunStatusClient.LockFor(duration)
         if typeof(duration) ~= "number" or duration <= 0 then return end
-        localLockUntil = math.max(localLockUntil, tick() + duration)
+        localLockUntil = math.max(localLockUntil, Time.now() + duration)
         if DEBUG then
             print("[StunStatusClient] Local lock for", duration)
         end
@@ -69,7 +70,7 @@ end
 -- otherwise last longer. This cannot shorten server-applied locks.
 function StunStatusClient.ReduceLockTo(duration)
     if typeof(duration) ~= "number" or duration < 0 then return end
-    local newEnd = tick() + duration
+    local newEnd = Time.now() + duration
     if newEnd < localLockUntil then
         localLockUntil = newEnd
         if DEBUG then

--- a/src/ReplicatedStorage/Modules/MenuCfgs/CameraManager.lua
+++ b/src/ReplicatedStorage/Modules/MenuCfgs/CameraManager.lua
@@ -3,6 +3,7 @@
 local RunService = game:GetService("RunService")
 local Lighting = game:GetService("Lighting")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local Workspace = game:GetService("Workspace")
 
 local Camera = workspace.CurrentCamera
@@ -55,7 +56,7 @@ function CameraManager.ApplyMenuCamera()
 			local y = startPos.Y
 
 			rotationConnection = RunService.RenderStepped:Connect(function()
-				local t = tick() * speed
+				local t = Time.now() * speed
 				local x = math.cos(t) * radius
 				local z = math.sin(t) * radius
 				local pos = Vector3.new(x, y, z)

--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -3,6 +3,7 @@
 local DashClient = {}
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local UserInputService = game:GetService("UserInputService")
 local Workspace = game:GetService("Workspace")
 local RunService = game:GetService("RunService")
@@ -173,7 +174,7 @@ function DashClient.OnInputBegan(input, gameProcessed)
     if input.UserInputType ~= Enum.UserInputType.Keyboard then return end
     if input.KeyCode ~= DASH_KEY then return end
 
-    if tick() - lastDashTime < DashConfig.Cooldown then return end
+    if Time.now() - lastDashTime < DashConfig.Cooldown then return end
     if StunStatusClient.IsStunned() or StunStatusClient.IsAttackerLocked() or BlockClient.IsBlocking() then return end
     -- Basic dashing should be available even when no tool is equipped. We only
     -- restrict dashing if a tool is equipped and specifically disallowed by the
@@ -192,7 +193,7 @@ function DashClient.OnInputBegan(input, gameProcessed)
                 styleKey = nil
         end
 
-        lastDashTime = tick()
+        lastDashTime = Time.now()
         MoveListManager.StartCooldown(DASH_KEY.Name, DashConfig.Cooldown or 0)
         playDashAnimation(direction)
 
@@ -229,10 +230,10 @@ function DashClient.OnInputBegan(input, gameProcessed)
 
 	-- The only dashes that are steerable (dynamic) are the "Forward" and "ForwardLeft/Right" ones.
 	if direction == "Forward" or direction == "ForwardLeft" or direction == "ForwardRight" then
-		local start = tick()
+		local start = Time.now()
 		dashConn = RunService.RenderStepped:Connect(function()
 			if not hrp or not humanoid then return end
-			if tick() - start > duration then
+			if Time.now() - start > duration then
 				if dashConn then dashConn:Disconnect() dashConn = nil end
 				return
 			end

--- a/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
+++ b/src/ReplicatedStorage/Modules/Stats/PersistentStatsService.lua
@@ -6,6 +6,7 @@ local Players = game:GetService("Players")
 local DataStoreService = game:GetService("DataStoreService")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local DEFAULT_DATA = {
     Kills = 0,
@@ -29,7 +30,7 @@ end
 local cache = {} -- [player] = data table
 local lastAttacker = {} -- [Humanoid] = player
 local processedDeaths = setmetatable({}, {__mode = "k"}) -- [Humanoid] = true
-local joinTimes = {} -- [player] = tick() when they joined
+local joinTimes = {} -- [player] = Time.now() when they joined
 
 local function loadPlayer(player)
     local data
@@ -105,7 +106,7 @@ end
 if RunService:IsServer() then
     Players.PlayerAdded:Connect(function(player)
         loadPlayer(player)
-        joinTimes[player] = tick()
+        joinTimes[player] = Time.now()
         player.CharacterAdded:Connect(function(char)
             trackCharacter(player, char)
         end)
@@ -116,7 +117,7 @@ if RunService:IsServer() then
 
     for _, p in ipairs(Players:GetPlayers()) do
         loadPlayer(p)
-        joinTimes[p] = tick()
+        joinTimes[p] = Time.now()
         if p.Character then
             trackCharacter(p, p.Character)
         end
@@ -125,7 +126,7 @@ if RunService:IsServer() then
     Players.PlayerRemoving:Connect(function(player)
         local join = joinTimes[player]
         if join then
-            local delta = tick() - join
+            local delta = Time.now() - join
             PersistentStatsService.AddStat(player, "PlaytimeHours", delta / 3600)
         end
         joinTimes[player] = nil

--- a/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
+++ b/src/ReplicatedStorage/Modules/UI/MoveListManager.lua
@@ -5,6 +5,7 @@ local MoveListManager = {}
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local ReplicatedFirst = game:GetService("ReplicatedFirst")
 
 local player = Players.LocalPlayer
@@ -142,10 +143,10 @@ function MoveListManager.StartCooldown(letter, duration)
         bar.Visible = true
         bar.Size = base
     end
-    local endTime = tick() + duration
+    local endTime = Time.now() + duration
 
     entry.conn = RunService.RenderStepped:Connect(function()
-        local remaining = endTime - tick()
+        local remaining = endTime - Time.now()
         if remaining <= 0 then
             if bar then
                 bar.Visible = false

--- a/src/ReplicatedStorage/Modules/Util/Time.lua
+++ b/src/ReplicatedStorage/Modules/Util/Time.lua
@@ -1,0 +1,15 @@
+-- ReplicatedStorage.Modules.Util.Time
+local RunService = game:GetService("RunService")
+
+local Time = {}
+
+-- Monotonic now(): on server use server time, on client use os.clock()
+function Time.now()
+    if RunService:IsServer() then
+        return workspace:GetServerTimeNow()
+    else
+        return os.clock()
+    end
+end
+
+return Time

--- a/src/ServerScriptService/AI/NPCController.server.lua
+++ b/src/ServerScriptService/AI/NPCController.server.lua
@@ -2,6 +2,7 @@
 -- Scans workspace.AI for NPC models and runs simple combat brains.
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local Workspace = game:GetService("Workspace")
 
 local AIConfig = require(ReplicatedStorage.Modules.Config.AIConfig)
@@ -57,7 +58,7 @@ local function bindNPC(model)
     task.spawn(function()
         while running and model.Parent do
             Perception.Update(bb, model)
-            bb.LastPerception = tick()
+            bb.LastPerception = Time.now()
             task.wait(1 / AIConfig.PerceptionHz)
         end
     end)

--- a/src/ServerScriptService/Combat/M1Service.lua
+++ b/src/ServerScriptService/Combat/M1Service.lua
@@ -6,6 +6,7 @@
 ]]
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local CombatConfig = require(ReplicatedStorage.Modules.Config.CombatConfig)
 local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
@@ -113,7 +114,7 @@ function M1Service.ProcessM1Request(actor, payload)
         return
     end
 
-    local now = tick()
+    local now = Time.now()
     comboState[char] = comboState[char] or {step = 0, lastTime = 0, cooldownEnd = 0}
     local state = comboState[char]
 

--- a/src/ServerScriptService/Combat/PartyTableKick.server.lua
+++ b/src/ServerScriptService/Combat/PartyTableKick.server.lua
@@ -1,4 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local RunService = game:GetService("RunService")
 local Players = game:GetService("Players")
 
@@ -99,7 +100,7 @@ StartEvent.OnServerEvent:Connect(function(player)
         return
     end
     StaminaService.PauseRegen(player)
-    activeDrain[player] = tick()
+    activeDrain[player] = Time.now()
     playAnimation(humanoid, AnimationData.SpecialMoves.PartyTableKick)
     if DEBUG then print("[PartyTableKick] Animation triggered") end
     local hrp = char:FindFirstChild("HumanoidRootPart")

--- a/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
+++ b/src/StarterPlayer/StarterCharacterScripts/AntiRagdollController.client.lua
@@ -2,6 +2,7 @@
 
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local StunStatusClient = require(ReplicatedStorage.Modules.Combat.StunStatusClient)
 
@@ -48,14 +49,14 @@ RunService.Heartbeat:Connect(function()
     end
 
 	-- Reset invalid physics states on delay
-        if tick() - lastCorrection >= CORRECTION_DELAY then
+        if Time.now() - lastCorrection >= CORRECTION_DELAY then
                 local state = humanoid:GetState()
                 local knockback = hrp:GetAttribute("KnockbackActive") or hrp:GetAttribute("Ragdolled")
                 if not knockback and (state == Enum.HumanoidStateType.Ragdoll
                         or state == Enum.HumanoidStateType.FallingDown
                         or state == Enum.HumanoidStateType.PlatformStanding) then
                         humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
-                        lastCorrection = tick()
+                        lastCorrection = Time.now()
                 end
         end
 

--- a/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/MainMenuClient.client.lua
@@ -1,6 +1,7 @@
 -- StarterPlayerScripts > MainMenuClient
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local ReplicatedFirst = game:GetService("ReplicatedFirst")
 local Players = game:GetService("Players")
 local TweenService = game:GetService("TweenService")
@@ -141,10 +142,10 @@ local function spawnAndFollow(toolName)
 	CameraManager.ClearMenuCamera()
 
 	-- 🔄 Enforce camera following for a short time
-	local startTime = tick()
+	local startTime = Time.now()
 	local conn
         conn = RunService.RenderStepped:Connect(function()
-                if tick() - startTime > 2 then
+                if Time.now() - startTime > 2 then
                         conn:Disconnect()
                 else
                         camera.CameraSubject = humanoid

--- a/src/Workspace/Rig/Animate.client.lua
+++ b/src/Workspace/Rig/Animate.client.lua
@@ -1,5 +1,7 @@
 -- humanoidAnimateR15Moods.lua
 
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 local Character = script.Parent
 local Humanoid = Character:WaitForChild("Humanoid")
 local pose = "Standing"
@@ -106,7 +108,7 @@ local animNames = {
 -- Existence in this list signifies that it is an emote, the value indicates if it is a looping emote
 local emoteNames = { wave = false, point = false, dance = true, dance2 = true, dance3 = true, laugh = false, cheer = false}
 
-math.randomseed(tick())
+math.randomseed(Time.now())
 
 function findExistingAnimationInSet(set, anim)
 	if set == nil or anim == nil then


### PR DESCRIPTION
## Summary
- add Time utility with monotonic `now` using server clock or `os.clock`
- swap `tick()` usages across project for `Time.now()`

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68a126f23e5c832d83e97008ce03a990