### PR TITLE
feat: add NPC sprint logic and movement animations

### DIFF
--- a/src/ReplicatedStorage/Modules/Animations/Movement.lua
+++ b/src/ReplicatedStorage/Modules/Animations/Movement.lua
@@ -12,7 +12,9 @@ Animation.Dash = {
 	BackwardLeft = "rbxassetid://117435369588116",
 }
 
-Animation.Sprint = "rbxassetid://85071486069251"
+Animation.Idle = "rbxassetid://YOUR_IDLE_ANIM_ID_HERE"
 Animation.Walk = "rbxassetid://YOUR_WALK_ANIM_ID_HERE"
+Animation.Run = "rbxassetid://YOUR_RUN_ANIM_ID_HERE"
+Animation.Sprint = "rbxassetid://85071486069251"
 
 return Animation


### PR DESCRIPTION
## Summary
- ensure NPCs have Animators and remove default Animate script
- drive idle/walk/run/sprint animations on the server
- boost NPC speed when engaging targets for auto-sprinting

## Testing
- `rojo sourcemap` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d3a6598832d8c1cb707f8b49229