### PR TITLE
feat: add distance-based npc engagement

### DIFF
--- a/src/ReplicatedStorage/Modules/AI/Blackboard.lua
+++ b/src/ReplicatedStorage/Modules/AI/Blackboard.lua
@@ -12,8 +12,12 @@ function Blackboard.new(level, levelConfig)
         Config = levelConfig,
         Target = nil,
         TargetDistance = math.huge,
+        DistanceBand = "Long",
+        IsClosing = false,
         IsBlocking = false,
         LastPerception = 0,
+        StrafeDir = 1,
+        NextStrafeChange = 0,
     }
     return setmetatable(self, Blackboard)
 end

--- a/src/ReplicatedStorage/Modules/AI/Decision.lua
+++ b/src/ReplicatedStorage/Modules/AI/Decision.lua
@@ -1,6 +1,10 @@
 --ReplicatedStorage.Modules.AI.Decision
 -- Simple utility-based decision maker.
 
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ToolConfig = require(ReplicatedStorage.Modules.Config.ToolConfig)
+local Time = require(ReplicatedStorage.Modules.Util.Time)
+
 local Decision = {}
 
 -- Evaluates current state and queues actions.
@@ -20,22 +24,59 @@ function Decision.Tick(model, bb, queue)
     local dist = (targetRoot.Position - hrp.Position).Magnitude
     bb.TargetDistance = dist
 
+    local styleKey = model:GetAttribute("StyleKey") or "BasicCombat"
+    local meta = ToolConfig.ToolMeta[styleKey]
+    local bands = meta and meta.IdealDistanceBand or { TooClose = 3, Ideal = 8, Long = 15 }
+
+    local band
+    if dist <= bands.TooClose then
+        band = "TooClose"
+    elseif dist <= bands.Ideal then
+        band = "Ideal"
+    else
+        band = "Long"
+    end
+    bb.DistanceBand = band
+    bb.IsClosing = false
+
     local hum = model:FindFirstChildOfClass("Humanoid")
-    if hum then
-        hum:MoveTo(targetRoot.Position)
+    if not hum then
+        return
     end
 
-    -- L1: only basic M1 when close
-    if dist <= 8 then
+    if band == "Long" then
+        bb.IsClosing = true
+        hum:MoveTo(targetRoot.Position)
+        if dist > bands.Long and bb.Level >= 2 and math.random() < 0.1 then
+            queue:Dash("Forward")
+        end
+    elseif band == "TooClose" then
+        hum:Move(hrp.CFrame.LookVector * -1)
+        if bb.Level >= 2 and math.random() < (bb.Config.DashDefense or 0) then
+            queue:Dash("Backward")
+        end
+    else -- Ideal band
+        if dist > bands.TooClose + 1 then
+            bb.IsClosing = true
+            hum:MoveTo(targetRoot.Position)
+        else
+            -- stop pathing and face target
+            hrp.CFrame = CFrame.lookAt(hrp.Position, Vector3.new(targetRoot.Position.X, hrp.Position.Y, targetRoot.Position.Z))
+
+            local now = Time.now()
+            if now >= bb.NextStrafeChange then
+                bb.StrafeDir = math.random(0, 1) == 0 and -1 or 1
+                bb.NextStrafeChange = now + math.random(1, 2)
+            end
+
+            hum:Move(hrp.CFrame.RightVector * bb.StrafeDir * 0.5)
+        end
         queue:PressM1()
     end
 
-    -- L2+: occasional blocking or dash back
+    -- L2+: occasional blocking
     if bb.Level >= 2 then
-        local cfg = bb.Config
-        if dist <= 10 and math.random() < (cfg.DashDefense or 0) then
-            queue:Dash("Backward")
-        elseif not bb.IsBlocking and math.random() < 0.1 then
+        if not bb.IsBlocking and math.random() < 0.1 then
             queue:StartBlock()
         elseif bb.IsBlocking and math.random() < 0.05 then
             queue:ReleaseBlock()

--- a/src/ServerScriptService/AI/NPCController.server.lua
+++ b/src/ServerScriptService/AI/NPCController.server.lua
@@ -119,7 +119,11 @@ local function bindNPC(model)
         local sprintSpeed = Config.GameSettings.DefaultSprintSpeed or 20
         while running and model.Parent do
             local engaged = bb.Target ~= nil
-            hum.WalkSpeed = engaged and sprintSpeed or defaultWalk
+            if engaged and (bb.DistanceBand == "Long" or bb.IsClosing) then
+                hum.WalkSpeed = sprintSpeed
+            else
+                hum.WalkSpeed = defaultWalk
+            end
 
             local state
             if hum.MoveDirection.Magnitude < 0.05 then


### PR DESCRIPTION
## Summary
- add distance band info to blackboard
- have Decision respect each style's IdealDistanceBand for movement/attacks
- sprint only while out of ideal range or closing to M1

## Testing
- `rojo sourcemap default.project.json | head -c 100`


------
https://chatgpt.com/codex/tasks/task_e_68a13accd1bc832d99c065cbd7380aed