### PR TITLE
feat: limit AI targeting to visible players

### DIFF
--- a/src/ReplicatedStorage/Modules/AI/Perception.lua
+++ b/src/ReplicatedStorage/Modules/AI/Perception.lua
@@ -1,7 +1,11 @@
 --ReplicatedStorage.Modules.AI.Perception
--- Naive perception: finds nearest alive player.
+-- Naive perception: finds nearest alive player within sight and line-of-sight.
 
 local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local AIConfig = require(ReplicatedStorage.Modules.Config.AIConfig)
+local Time = require(ReplicatedStorage.Modules.Util.Time)
 
 local Perception = {}
 
@@ -16,23 +20,54 @@ function Perception.Update(bb, model)
         return
     end
 
+    local now = Time.now()
+    local sightRange = (AIConfig.Detection and AIConfig.Detection.SightRange) or 90
+    local loseSightTime = (AIConfig.Detection and AIConfig.Detection.LoseSightTime) or 2.0
+
+    local params = RaycastParams.new()
+    params.FilterType = Enum.RaycastFilterType.Exclude
+
     local nearest
     local nearestDist = math.huge
+
     for _, p in ipairs(Players:GetPlayers()) do
         local char = p.Character
         local hum = char and char:FindFirstChildOfClass("Humanoid")
         local root = char and char:FindFirstChild("HumanoidRootPart")
         if hum and hum.Health > 0 and root then
             local d = (root.Position - hrp.Position).Magnitude
-            if d < nearestDist then
-                nearest = char
-                nearestDist = d
+            if d <= sightRange and d < nearestDist then
+                params.FilterDescendantsInstances = { model, char }
+                local result = workspace:Raycast(hrp.Position, root.Position - hrp.Position, params)
+                if not result then
+                    nearest = char
+                    nearestDist = d
+                end
             end
         end
     end
 
-    bb.Target = nearest
-    bb.TargetDistance = nearestDist
+    if nearest then
+        bb.Target = nearest
+        bb.TargetDistance = nearestDist
+        bb.LastSeenTime = now
+    else
+        if bb.Target then
+            local targetRoot = bb.Target:FindFirstChild("HumanoidRootPart")
+            if targetRoot then
+                bb.TargetDistance = (targetRoot.Position - hrp.Position).Magnitude
+            else
+                bb.TargetDistance = math.huge
+            end
+            if now - (bb.LastSeenTime or 0) > loseSightTime then
+                bb.Target = nil
+                bb.TargetDistance = math.huge
+                bb.LastSeenTime = 0
+            end
+        else
+            bb.TargetDistance = math.huge
+        end
+    end
 end
 
 return Perception

--- a/src/ReplicatedStorage/Modules/Config/AIConfig.lua
+++ b/src/ReplicatedStorage/Modules/Config/AIConfig.lua
@@ -5,6 +5,7 @@ return {
   PerceptionHz = 15,
   DecisionHz   = 7,
   SeededRNG    = true,
+  Detection    = { SightRange = 90, LoseSightTime = 2.0 },
   Levels = {
     [1] = {Aggression=0.55, FeintChance=0.00, PerfectBlock=0.00, WhiffPunish=0.00, UseAbilities=0.00, DashOffense=0.00, DashDefense=0.05, Strafing=0.10, Predictability=0.80, ComboVariety=0.10, RepetitionPenalty=0.05, ReactionTimeMs={min=260,max=360}, MicroJitterMs={min=40,max=90}},
     [2] = {Aggression=0.55, FeintChance=0.00, PerfectBlock=0.00, WhiffPunish=0.05, UseAbilities=0.00, DashOffense=0.00, DashDefense=0.12, Strafing=0.20, Predictability=0.65, ComboVariety=0.25, RepetitionPenalty=0.12, ReactionTimeMs={min=220,max=300}, MicroJitterMs={min=30,max=80}},


### PR DESCRIPTION
## Summary
- configure NPC detection range and lose-sight timeout
- raycast for line-of-sight and drop targets when unseen

## Testing
- `rojo build default.project.json -o game.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68a1f1854ef0832dafc0858560020ad8