### PR TITLE
fix: prevent dash cancellation error

### DIFF
--- a/src/ReplicatedStorage/Modules/Movement/DashClient.lua
+++ b/src/ReplicatedStorage/Modules/Movement/DashClient.lua
@@ -38,6 +38,17 @@ local function resolveChar(actor)
        return nil
 end
 
+-- Helper to safely get common character components
+local function getCharacterComponents()
+        local character = player.Character
+        if not character then return nil end
+        local humanoid = character:FindFirstChildOfClass("Humanoid")
+        if not humanoid then return nil end
+        local animator = humanoid:FindFirstChildOfClass("Animator")
+        local hrp = character:FindFirstChild("HumanoidRootPart")
+        return character, humanoid, animator, hrp
+end
+
 -- Immediately stop any active dash and clear velocity
 function DashClient.CancelDash()
     if dashConn then
@@ -104,16 +115,6 @@ local function setCharacterInvisible(character, invisible, owner)
             obj.Enabled = not invisible
         end
     end
-end
-
-local function getCharacterComponents()
-	local character = player.Character
-	if not character then return nil end
-	local humanoid = character:FindFirstChildOfClass("Humanoid")
-	if not humanoid then return nil end
-	local animator = humanoid:FindFirstChildOfClass("Animator")
-	local hrp = character:FindFirstChild("HumanoidRootPart")
-	return character, humanoid, animator, hrp
 end
 
 -- 🚨 CAMERA-RELATIVE DASHING!


### PR DESCRIPTION
## Summary
- define `getCharacterComponents` before `CancelDash`
- ensure dash cancellation handles missing components safely

## Testing
- `./rojo-bin/rojo build default.project.json -o game.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0002020832dba44b127342588ec