### PR TITLE
Add combat system foundation with NPC support

### DIFF
--- a/src/ReplicatedStorage/Combat/CharacterState.lua
+++ b/src/ReplicatedStorage/Combat/CharacterState.lua
@@ -1,0 +1,141 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local CombatConstants = require(ReplicatedStorage:WaitForChild("Combat"):WaitForChild("CombatConstants"))
+
+local CharacterState = {}
+CharacterState.__index = CharacterState
+
+function CharacterState.new(character)
+    assert(typeof(character) == "Instance", "CharacterState.new expects an Instance")
+
+    local humanoid = character:FindFirstChildOfClass("Humanoid")
+    if not humanoid then
+        return nil
+    end
+
+    local self = setmetatable({}, CharacterState)
+    self.Character = character
+    self.Humanoid = humanoid
+    self.Blocking = false
+    self.Destroyed = false
+    self.LastAttackTime = 0
+    self.Stamina = CombatConstants.STAMINA.Max
+    self.Connections = {}
+
+    table.insert(self.Connections, character.AncestryChanged:Connect(function(_, parent)
+        if not parent then
+            self:Destroy()
+        end
+    end))
+
+    table.insert(self.Connections, humanoid.Died:Connect(function()
+        self:Destroy()
+    end))
+
+    return self
+end
+
+function CharacterState:IsAlive()
+    local humanoid = self.Humanoid
+    return humanoid ~= nil and humanoid.Health > 0 and humanoid.Parent ~= nil
+end
+
+function CharacterState:GetHumanoid()
+    return self.Humanoid
+end
+
+function CharacterState:GetCharacter()
+    return self.Character
+end
+
+function CharacterState:GetRootPart()
+    local character = self.Character
+    if not character then
+        return nil
+    end
+
+    return character:FindFirstChild("HumanoidRootPart") or character.PrimaryPart
+end
+
+function CharacterState:IsBlocking()
+    return self.Blocking
+end
+
+function CharacterState:SetBlocking(isBlocking)
+    if isBlocking and not self.Blocking then
+        if self.Stamina < CombatConstants.STAMINA.BlockStartCost then
+            return false
+        end
+        self:SpendStamina(CombatConstants.STAMINA.BlockStartCost)
+    end
+
+    self.Blocking = isBlocking
+    return true
+end
+
+function CharacterState:CanAttack(attackType)
+    if self.Destroyed or not self:IsAlive() then
+        return false, "NotAlive"
+    end
+
+    local now = os.clock()
+    if now - self.LastAttackTime < CombatConstants.ATTACK_COOLDOWN then
+        return false, "Cooldown"
+    end
+
+    local cost = CombatConstants.STAMINA.AttackCost[attackType]
+    if cost and self.Stamina < cost then
+        return false, "NoStamina"
+    end
+
+    return true
+end
+
+function CharacterState:RecordAttack(attackType)
+    self.LastAttackTime = os.clock()
+    local cost = CombatConstants.STAMINA.AttackCost[attackType]
+    if cost then
+        self:SpendStamina(cost)
+    end
+end
+
+function CharacterState:SpendStamina(amount)
+    self.Stamina = math.max(0, self.Stamina - amount)
+end
+
+function CharacterState:RegenerateStamina(dt)
+    if self.Destroyed then
+        return
+    end
+
+    local regen = CombatConstants.STAMINA_REGEN_PER_SECOND * dt
+    if self.Blocking then
+        regen -= CombatConstants.BLOCK_STAMINA_DRAIN_PER_SECOND * dt
+    end
+
+    self.Stamina = math.clamp(self.Stamina + regen, 0, CombatConstants.STAMINA.Max)
+end
+
+function CharacterState:ApplyDamage(amount)
+    local humanoid = self.Humanoid
+    if not humanoid or amount <= 0 then
+        return
+    end
+
+    humanoid:TakeDamage(amount)
+end
+
+function CharacterState:Destroy()
+    if self.Destroyed then
+        return
+    end
+
+    self.Destroyed = true
+    for _, connection in ipairs(self.Connections) do
+        connection:Disconnect()
+    end
+
+    table.clear(self.Connections)
+end
+
+return CharacterState

--- a/src/ReplicatedStorage/Combat/CombatConstants.lua
+++ b/src/ReplicatedStorage/Combat/CombatConstants.lua
@@ -1,0 +1,25 @@
+local CombatConstants = {
+    ATTACK_COOLDOWN = 0.55,
+    BLOCK_STAMINA_DRAIN_PER_SECOND = 20,
+    STAMINA_REGEN_PER_SECOND = 15,
+    DAMAGE = {
+        Light = 12,
+        Heavy = 28,
+    },
+    STAMINA = {
+        Max = 100,
+        AttackCost = {
+            Light = 12,
+            Heavy = 32,
+        },
+        BlockStartCost = 8,
+    },
+    RANGE = {
+        Light = 10,
+        Heavy = 12,
+    },
+    NPC_ATTACK_INTERVAL = 2.5,
+    NPC_DETECTION_RADIUS = 45,
+}
+
+return CombatConstants

--- a/src/ReplicatedStorage/Combat/DamageCalculator.lua
+++ b/src/ReplicatedStorage/Combat/DamageCalculator.lua
@@ -1,0 +1,33 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local CombatConstants = require(ReplicatedStorage:WaitForChild("Combat"):WaitForChild("CombatConstants"))
+
+local DamageCalculator = {}
+
+function DamageCalculator.Calculate(attackerState, defenderState, attackType, metadata)
+    metadata = metadata or {}
+
+    local baseDamage = CombatConstants.DAMAGE[attackType] or 0
+    if baseDamage <= 0 then
+        return 0
+    end
+
+    local damageMultiplier = 1
+
+    if defenderState and defenderState:IsBlocking() then
+        damageMultiplier *= 0.3
+    end
+
+    if metadata.Headshot then
+        damageMultiplier *= 1.5
+    end
+
+    if metadata.ComboMultiplier then
+        damageMultiplier *= metadata.ComboMultiplier
+    end
+
+    local damage = math.floor(baseDamage * damageMultiplier)
+    return math.max(damage, 0)
+end
+
+return DamageCalculator

--- a/src/ReplicatedStorage/Remotes/Combat.event.json
+++ b/src/ReplicatedStorage/Remotes/Combat.event.json
@@ -1,0 +1,4 @@
+{
+  "Name": "Combat",
+  "ClassName": "RemoteEvent"
+}

--- a/src/ServerScriptService/CombatService/Main.server.lua
+++ b/src/ServerScriptService/CombatService/Main.server.lua
@@ -1,0 +1,3 @@
+local serviceModule = require(script:WaitForChild("Service"))
+
+serviceModule.Start()

--- a/src/ServerScriptService/CombatService/Service.lua
+++ b/src/ServerScriptService/CombatService/Service.lua
@@ -1,0 +1,275 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local combatFolder = ReplicatedStorage:WaitForChild("Combat")
+local remotesFolder = ReplicatedStorage:WaitForChild("Remotes")
+local combatRemote = remotesFolder:WaitForChild("Combat")
+
+local CombatConstants = require(combatFolder:WaitForChild("CombatConstants"))
+local CharacterState = require(combatFolder:WaitForChild("CharacterState"))
+local DamageCalculator = require(combatFolder:WaitForChild("DamageCalculator"))
+
+local CombatService = {}
+
+local statesByCharacter = {}
+local statesByHumanoid = {}
+local connections = {}
+
+local function cleanupState(character)
+    local state = statesByCharacter[character]
+    if not state then
+        return
+    end
+
+    statesByCharacter[character] = nil
+
+    local humanoid = state:GetHumanoid()
+    if humanoid then
+        statesByHumanoid[humanoid] = nil
+    end
+
+    state:Destroy()
+end
+
+local function trackState(state)
+    local character = state:GetCharacter()
+    if not character then
+        return
+    end
+
+    local humanoid = state:GetHumanoid()
+
+    local ancestryConn
+    ancestryConn = character.AncestryChanged:Connect(function(_, parent)
+        if not parent then
+            cleanupState(character)
+            if ancestryConn.Connected then
+                ancestryConn:Disconnect()
+            end
+        end
+    end)
+    table.insert(state.Connections, ancestryConn)
+
+    if humanoid then
+        local humanoidConn
+        humanoidConn = humanoid.AncestryChanged:Connect(function(_, parent)
+            if not parent then
+                cleanupState(character)
+                if humanoidConn.Connected then
+                    humanoidConn:Disconnect()
+                end
+            end
+        end)
+        table.insert(state.Connections, humanoidConn)
+    end
+end
+
+function CombatService.GetStateFromCharacter(character)
+    return statesByCharacter[character]
+end
+
+function CombatService.GetStateFromHumanoid(humanoid)
+    return statesByHumanoid[humanoid]
+end
+
+function CombatService.GetOrCreateState(character)
+    if typeof(character) ~= "Instance" or not character:IsA("Model") then
+        return nil
+    end
+
+    local state = statesByCharacter[character]
+    if state and not state.Destroyed then
+        return state
+    end
+
+    state = CharacterState.new(character)
+    if not state then
+        return nil
+    end
+
+    statesByCharacter[character] = state
+    statesByHumanoid[state:GetHumanoid()] = state
+
+    trackState(state)
+
+    return state
+end
+
+local function resolveCharacterFromInstance(instance)
+    if typeof(instance) ~= "Instance" then
+        return nil
+    end
+
+    if instance:IsA("Model") then
+        if instance:FindFirstChildOfClass("Humanoid") then
+            return instance
+        end
+    end
+
+    if instance:IsA("Humanoid") then
+        return instance.Parent
+    end
+
+    local parent = instance.Parent
+    while parent do
+        if parent:IsA("Model") and parent:FindFirstChildOfClass("Humanoid") then
+            return parent
+        end
+        parent = parent.Parent
+    end
+
+    return nil
+end
+
+local function isInRange(attackerState, defenderState, attackType)
+    local range = CombatConstants.RANGE[attackType]
+    if not range then
+        range = CombatConstants.RANGE.Light or 10
+    end
+
+    local attackerRoot = attackerState and attackerState:GetRootPart()
+    local defenderRoot = defenderState and defenderState:GetRootPart()
+
+    if not attackerRoot or not defenderRoot then
+        return false
+    end
+
+    local distance = (attackerRoot.Position - defenderRoot.Position).Magnitude
+    return distance <= range
+end
+
+local function processAttack(attackerCharacter, attackType, targetCharacter, metadata)
+    metadata = metadata or {}
+
+    local attackerState = CombatService.GetOrCreateState(attackerCharacter)
+    if not attackerState then
+        return false, "NoAttacker"
+    end
+
+    local canAttack, reason = attackerState:CanAttack(attackType)
+    if not canAttack then
+        return false, reason
+    end
+
+    local defenderState = CombatService.GetOrCreateState(targetCharacter)
+    if not defenderState or not defenderState:IsAlive() then
+        return false, "InvalidTarget"
+    end
+
+    if not isInRange(attackerState, defenderState, attackType) then
+        return false, "OutOfRange"
+    end
+
+    local damage = DamageCalculator.Calculate(attackerState, defenderState, attackType, metadata)
+    if damage <= 0 then
+        return false, "NoDamage"
+    end
+
+    attackerState:RecordAttack(attackType)
+    defenderState:ApplyDamage(damage)
+
+    return true
+end
+
+local function handlePlayerAttack(player, payload)
+    payload = payload or {}
+    local character = player.Character
+    if not character then
+        return
+    end
+
+    local attackType = payload.AttackType or "Light"
+    local targetInstance = payload.Target
+    local targetCharacter = resolveCharacterFromInstance(targetInstance)
+    if not targetCharacter then
+        return
+    end
+
+    processAttack(character, attackType, targetCharacter, payload.Metadata)
+end
+
+local function handlePlayerBlock(player, payload)
+    payload = payload or {}
+    local character = player.Character
+    if not character then
+        return
+    end
+
+    local state = CombatService.GetOrCreateState(character)
+    if not state then
+        return
+    end
+
+    if payload.IsBlocking == true then
+        state:SetBlocking(true)
+    elseif payload.IsBlocking == false then
+        state:SetBlocking(false)
+    end
+end
+
+local function onRemoteEvent(player, action, payload)
+    if action == "Attack" then
+        handlePlayerAttack(player, payload)
+    elseif action == "Block" then
+        handlePlayerBlock(player, payload)
+    end
+end
+
+local function onPlayerAdded(player)
+    local function onCharacterAdded(character)
+        CombatService.GetOrCreateState(character)
+    end
+
+    table.insert(connections, player.CharacterAdded:Connect(onCharacterAdded))
+
+    if player.Character then
+        onCharacterAdded(player.Character)
+    end
+end
+
+local function onPlayerRemoving(player)
+    local character = player.Character
+    if character then
+        cleanupState(character)
+    end
+end
+
+function CombatService.Start()
+    for _, player in ipairs(Players:GetPlayers()) do
+        onPlayerAdded(player)
+    end
+
+    table.insert(connections, Players.PlayerAdded:Connect(onPlayerAdded))
+    table.insert(connections, Players.PlayerRemoving:Connect(onPlayerRemoving))
+
+    table.insert(connections, combatRemote.OnServerEvent:Connect(onRemoteEvent))
+
+    table.insert(connections, RunService.Heartbeat:Connect(function(dt)
+        for character, state in pairs(statesByCharacter) do
+            if state.Destroyed or not state:IsAlive() then
+                cleanupState(character)
+            else
+                state:RegenerateStamina(dt)
+            end
+        end
+    end))
+end
+
+function CombatService.ProcessAttack(attackerCharacter, targetCharacter, attackType, metadata)
+    attackType = attackType or "Light"
+    return processAttack(attackerCharacter, attackType, targetCharacter, metadata)
+end
+
+function CombatService.Cleanup()
+    for character in pairs(statesByCharacter) do
+        cleanupState(character)
+    end
+
+    for _, connection in ipairs(connections) do
+        connection:Disconnect()
+    end
+    table.clear(connections)
+end
+
+return CombatService

--- a/src/ServerScriptService/NPCService.server.lua
+++ b/src/ServerScriptService/NPCService.server.lua
@@ -1,0 +1,167 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local Workspace = game:GetService("Workspace")
+
+local combatFolder = ReplicatedStorage:WaitForChild("Combat")
+local CombatConstants = require(combatFolder:WaitForChild("CombatConstants"))
+local CombatService = require(script.Parent:WaitForChild("CombatService"):WaitForChild("Service"))
+
+local NPCService = {}
+
+local npcs = {}
+
+local function createNPCModel(position)
+    local model = Instance.new("Model")
+    model.Name = "CombatNPC"
+
+    local root = Instance.new("Part")
+    root.Name = "HumanoidRootPart"
+    root.Size = Vector3.new(2, 5, 2)
+    root.CFrame = CFrame.new(position)
+    root.Anchored = false
+    root.Parent = model
+
+    local head = Instance.new("Part")
+    head.Name = "Head"
+    head.Size = Vector3.new(2, 1, 2)
+    head.CFrame = root.CFrame * CFrame.new(0, 3, 0)
+    head.Anchored = false
+    head.Parent = model
+
+    local weld = Instance.new("WeldConstraint")
+    weld.Part0 = root
+    weld.Part1 = head
+    weld.Parent = root
+
+    local humanoid = Instance.new("Humanoid")
+    humanoid.Name = "Humanoid"
+    humanoid.MaxHealth = 150
+    humanoid.Health = humanoid.MaxHealth
+    humanoid.WalkSpeed = 14
+    humanoid.JumpPower = 0
+    humanoid.Parent = model
+
+    model.PrimaryPart = root
+    model:SetAttribute("IsNPC", true)
+    model.Parent = Workspace
+
+    return model, humanoid
+end
+
+local function findTarget(position)
+    local closestCharacter
+    local closestDistance = math.huge
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        local character = player.Character
+        local state = CombatService.GetOrCreateState(character)
+        if state and state:IsAlive() then
+            local rootPart = state:GetRootPart()
+            if rootPart then
+                local distance = (rootPart.Position - position).Magnitude
+                if distance < closestDistance and distance <= CombatConstants.NPC_DETECTION_RADIUS then
+                    closestCharacter = character
+                    closestDistance = distance
+                end
+            end
+        end
+    end
+
+    return closestCharacter
+end
+
+function NPCService.SpawnNPC(position)
+    local model, humanoid = createNPCModel(position)
+    local state = CombatService.GetOrCreateState(model)
+    if not state then
+        model:Destroy()
+        return nil
+    end
+
+    local npcData = {
+        Model = model,
+        Humanoid = humanoid,
+        NextAttack = CombatConstants.NPC_ATTACK_INTERVAL,
+        Target = nil,
+    }
+
+    npcs[model] = npcData
+
+    humanoid.Died:Connect(function()
+        npcs[model] = nil
+    end)
+
+    return model
+end
+
+local function updateNPC(npcData, dt)
+    local model = npcData.Model
+    local state = CombatService.GetOrCreateState(model)
+    if not state or state.Destroyed or not state:IsAlive() then
+        npcs[model] = nil
+        return
+    end
+
+    local rootPart = state:GetRootPart()
+    if not rootPart then
+        return
+    end
+
+    if not npcData.Target or not CombatService.GetOrCreateState(npcData.Target) then
+        npcData.Target = findTarget(rootPart.Position)
+    end
+
+    local targetCharacter = npcData.Target
+    if not targetCharacter then
+        return
+    end
+
+    local targetState = CombatService.GetOrCreateState(targetCharacter)
+    if not targetState or not targetState:IsAlive() then
+        npcData.Target = nil
+        return
+    end
+
+    local targetRoot = targetState:GetRootPart()
+    if not targetRoot then
+        npcData.Target = nil
+        return
+    end
+
+    local distance = (targetRoot.Position - rootPart.Position).Magnitude
+
+    if distance > CombatConstants.RANGE.Light then
+        npcData.Humanoid:MoveTo(targetRoot.Position)
+    else
+        npcData.Humanoid:Move(Vector3.zero, true)
+    end
+
+    npcData.NextAttack -= dt
+    if npcData.NextAttack <= 0 then
+        local success = CombatService.ProcessAttack(model, targetCharacter, "Light")
+        if success then
+            npcData.NextAttack = CombatConstants.NPC_ATTACK_INTERVAL
+        else
+            npcData.NextAttack = 0.5
+        end
+    end
+end
+
+local spawnPositions = {
+    Vector3.new(0, 5, 0),
+    Vector3.new(12, 5, 8),
+    Vector3.new(-14, 5, -6),
+}
+
+for _, position in ipairs(spawnPositions) do
+    NPCService.SpawnNPC(position)
+end
+
+RunService.Heartbeat:Connect(function(dt)
+    for _, npcData in pairs(npcs) do
+        updateNPC(npcData, dt)
+    end
+end)
+
+return NPCService

--- a/src/StarterPlayer/StarterPlayerScripts/CombatController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CombatController.client.lua
@@ -1,0 +1,85 @@
+local Players = game:GetService("Players")
+local ContextActionService = game:GetService("ContextActionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local player = Players.LocalPlayer
+local mouse = player:GetMouse()
+
+local combatFolder = ReplicatedStorage:WaitForChild("Combat")
+local CombatConstants = require(combatFolder:WaitForChild("CombatConstants"))
+local combatRemote = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Combat")
+
+local currentTargetHumanoid
+
+local function findHumanoidFromPart(part)
+    if not part then
+        return nil
+    end
+
+    local model = part:FindFirstAncestorWhichIsA("Model")
+    if not model or model == player.Character then
+        return nil
+    end
+
+    return model:FindFirstChildOfClass("Humanoid")
+end
+
+local function sendAttack(attackType, targetHumanoid)
+    combatRemote:FireServer("Attack", {
+        AttackType = attackType,
+        Target = targetHumanoid,
+    })
+end
+
+local function performAttack(attackType)
+    local targetHumanoid = currentTargetHumanoid
+    if not targetHumanoid or targetHumanoid.Health <= 0 then
+        targetHumanoid = findHumanoidFromPart(mouse.Target)
+    end
+
+    sendAttack(attackType, targetHumanoid)
+end
+
+local function lightAttackAction(_, inputState)
+    if inputState ~= Enum.UserInputState.Begin then
+        return Enum.ContextActionResult.Pass
+    end
+
+    performAttack("Light")
+    return Enum.ContextActionResult.Sink
+end
+
+local function heavyAttackAction(_, inputState)
+    if inputState ~= Enum.UserInputState.Begin then
+        return Enum.ContextActionResult.Pass
+    end
+
+    performAttack("Heavy")
+    return Enum.ContextActionResult.Sink
+end
+
+local function blockAction(_, inputState)
+    if inputState == Enum.UserInputState.Begin then
+        combatRemote:FireServer("Block", {
+            IsBlocking = true,
+        })
+    elseif inputState == Enum.UserInputState.End or inputState == Enum.UserInputState.Cancel then
+        combatRemote:FireServer("Block", {
+            IsBlocking = false,
+        })
+    end
+
+    return Enum.ContextActionResult.Sink
+end
+
+RunService.RenderStepped:Connect(function()
+    local targetHumanoid = findHumanoidFromPart(mouse.Target)
+    currentTargetHumanoid = targetHumanoid
+end)
+
+ContextActionService:BindAction("LightAttack", lightAttackAction, false, Enum.UserInputType.MouseButton1)
+ContextActionService:BindAction("HeavyAttack", heavyAttackAction, false, Enum.UserInputType.MouseButton2, Enum.KeyCode.Q)
+ContextActionService:BindAction("Block", blockAction, false, Enum.KeyCode.F)
+
+return {}


### PR DESCRIPTION
## Summary
- add shared combat modules for combat constants, character state handling, and damage calculation
- implement a server CombatService that validates attacks/blocks, maintains stamina, and wires remotes
- scaffold an NPC service and client combat controller that drive remote combat interactions

## Testing
- not run (Roblox project, no automated test suite provided)

------
https://chatgpt.com/codex/tasks/task_e_68d556cdf018832db64fe74e319c2f97