### PR TITLE
Fix combat service references and ensure remotes

### DIFF
--- a/src/ServerScriptService/CombatService/Main.server.lua
+++ b/src/ServerScriptService/CombatService/Main.server.lua
@@ -1,3 +1,3 @@
-local serviceModule = require(script:WaitForChild("Service"))
+local serviceModule = require(script.Parent:WaitForChild("Service"))
 
 serviceModule.Start()

--- a/src/ServerScriptService/CombatService/Service.lua
+++ b/src/ServerScriptService/CombatService/Service.lua
@@ -3,8 +3,20 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 
 local combatFolder = ReplicatedStorage:WaitForChild("Combat")
-local remotesFolder = ReplicatedStorage:WaitForChild("Remotes")
-local combatRemote = remotesFolder:WaitForChild("Combat")
+
+local remotesFolder = ReplicatedStorage:FindFirstChild("Remotes")
+if not remotesFolder then
+    remotesFolder = Instance.new("Folder")
+    remotesFolder.Name = "Remotes"
+    remotesFolder.Parent = ReplicatedStorage
+end
+
+local combatRemote = remotesFolder:FindFirstChild("Combat")
+if not combatRemote then
+    combatRemote = Instance.new("RemoteEvent")
+    combatRemote.Name = "Combat"
+    combatRemote.Parent = remotesFolder
+end
 
 local configFolder = ReplicatedStorage:WaitForChild("Config")
 


### PR DESCRIPTION
## Summary
- load the combat service module from the parent folder instead of the script
- ensure the Remotes folder and Combat remote event exist before using them

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d58258d040832da6ca4eb3674d8f5d